### PR TITLE
Add Node.js backend skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,22 @@ npm install
 npm run dev
 ```
 
+### Development
+
+The backend is built with **Node.js** using **Express**. Start the server in
+development mode with:
+
+```bash
+npm run dev
+```
+
+It will reload automatically on changes thanks to **nodemon**. To run the server
+normally, use:
+
+```bash
+npm start
+```
+
 ## 🧐 Roadmap Ideas
 
 * ✅ Manual input of bills and subscriptions

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "bill-tracker-dashboard",
+  "version": "1.0.0",
+  "description": "A basic Node.js backend for the Bill Tracker Dashboard",
+  "main": "src/index.js",
+  "type": "module",
+  "scripts": {
+    "start": "node src/index.js",
+    "dev": "nodemon src/index.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "express": "^4.18.2",
+    "uuid": "^9.0.0"
+  },
+  "devDependencies": {
+    "nodemon": "^3.0.2"
+  }
+}

--- a/src/controllers/billController.js
+++ b/src/controllers/billController.js
@@ -1,0 +1,54 @@
+import {
+  listBills,
+  getBillById,
+  addBill,
+  updateBill,
+  deleteBill
+} from '../services/billService.js';
+
+export const getAll = (req, res, next) => {
+  try {
+    res.json(listBills());
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const getById = (req, res, next) => {
+  try {
+    const bill = getBillById(req.params.id);
+    if (!bill) return res.status(404).json({ message: 'Bill not found' });
+    res.json(bill);
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const create = (req, res, next) => {
+  try {
+    const bill = addBill(req.body);
+    res.status(201).json(bill);
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const update = (req, res, next) => {
+  try {
+    const bill = updateBill(req.params.id, req.body);
+    if (!bill) return res.status(404).json({ message: 'Bill not found' });
+    res.json(bill);
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const remove = (req, res, next) => {
+  try {
+    const success = deleteBill(req.params.id);
+    if (!success) return res.status(404).json({ message: 'Bill not found' });
+    res.status(204).end();
+  } catch (err) {
+    next(err);
+  }
+};

--- a/src/db/mockDb.js
+++ b/src/db/mockDb.js
@@ -1,0 +1,18 @@
+// Simple in-memory storage for bills
+const bills = new Map();
+
+export default {
+  getBills: () => Array.from(bills.values()),
+  getBill: (id) => bills.get(id),
+  addBill: (bill) => {
+    bills.set(bill.id, bill);
+    return bill;
+  },
+  updateBill: (id, data) => {
+    if (!bills.has(id)) return null;
+    const updated = { ...bills.get(id), ...data };
+    bills.set(id, updated);
+    return updated;
+  },
+  deleteBill: (id) => bills.delete(id)
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,17 @@
+import express from 'express';
+import billRoutes from './routes/billRoutes.js';
+import logger from './middleware/logger.js';
+import errorHandler from './middleware/errorHandler.js';
+
+const app = express();
+app.use(express.json());
+app.use(logger);
+
+app.use('/bills', billRoutes);
+
+app.use(errorHandler);
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});

--- a/src/middleware/errorHandler.js
+++ b/src/middleware/errorHandler.js
@@ -1,0 +1,4 @@
+export default (err, req, res, next) => {
+  console.error(err.stack);
+  res.status(500).json({ message: 'Internal Server Error' });
+};

--- a/src/middleware/logger.js
+++ b/src/middleware/logger.js
@@ -1,0 +1,4 @@
+export default (req, res, next) => {
+  console.log(`${new Date().toISOString()} ${req.method} ${req.url}`);
+  next();
+};

--- a/src/routes/billRoutes.js
+++ b/src/routes/billRoutes.js
@@ -1,0 +1,12 @@
+import { Router } from 'express';
+import * as controller from '../controllers/billController.js';
+
+const router = Router();
+
+router.get('/', controller.getAll);
+router.get('/:id', controller.getById);
+router.post('/', controller.create);
+router.put('/:id', controller.update);
+router.delete('/:id', controller.remove);
+
+export default router;

--- a/src/services/billService.js
+++ b/src/services/billService.js
@@ -1,0 +1,15 @@
+import db from '../db/mockDb.js';
+import { v4 as uuidv4 } from 'uuid';
+
+export const listBills = () => db.getBills();
+
+export const getBillById = (id) => db.getBill(id);
+
+export const addBill = (data) => {
+  const bill = { id: uuidv4(), ...data };
+  return db.addBill(bill);
+};
+
+export const updateBill = (id, data) => db.updateBill(id, data);
+
+export const deleteBill = (id) => db.deleteBill(id);


### PR DESCRIPTION
## Summary
- create express server with routes, controllers, services, and mock DB
- add request logger and error handler middleware
- add package.json with ES module config and nodemon scripts
- update README with development instructions

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `node src/index.js` *(fails: Cannot find package 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6843ba553ed4832f8762242eab20dbf5