### PR TITLE
Add dashboard filters and Vue frontend

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Bill Tracker Dashboard</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "bill-tracker-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "axios": "^1.6.2",
+    "vue": "^3.3.4"
+  },
+  "devDependencies": {
+    "vite": "^4.4.9",
+    "@vitejs/plugin-vue": "^4.2.3"
+  }
+}

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,0 +1,30 @@
+<template>
+  <div class="container">
+    <h1>Bill Tracker Dashboard</h1>
+    <SummaryWidget />
+    <BillForm @added="refresh" />
+    <BillTable :key="refreshKey" />
+  </div>
+</template>
+
+<script setup>
+import BillTable from './components/BillTable.vue';
+import BillForm from './components/BillForm.vue';
+import SummaryWidget from './components/SummaryWidget.vue';
+import { ref } from 'vue';
+
+const refreshKey = ref(0);
+
+function refresh() {
+  refreshKey.value++;
+}
+</script>
+
+<style>
+.container {
+  max-width: 900px;
+  margin: auto;
+  padding: 20px;
+  font-family: Arial, Helvetica, sans-serif;
+}
+</style>

--- a/frontend/src/components/BillForm.vue
+++ b/frontend/src/components/BillForm.vue
@@ -1,0 +1,73 @@
+<template>
+  <form @submit.prevent="submit">
+    <input v-model="name" placeholder="Name" required />
+    <input v-model="description" placeholder="Description" />
+    <input type="number" v-model.number="amount" placeholder="Amount" required />
+    <input type="date" v-model="dueDate" required />
+    <select v-model="category">
+      <option value="utilities">Utilities</option>
+      <option value="subscriptions">Subscriptions</option>
+      <option value="taxes">Taxes</option>
+      <option value="others">Others</option>
+    </select>
+    <button type="submit" :disabled="loading">Add</button>
+  </form>
+  <div v-if="error" class="error">{{ error }}</div>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+import axios from 'axios';
+
+const emit = defineEmits(['added']);
+
+const name = ref('');
+const description = ref('');
+const amount = ref(0);
+const dueDate = ref('');
+const category = ref('utilities');
+const loading = ref(false);
+const error = ref(null);
+
+const submit = async () => {
+  loading.value = true;
+  try {
+    await axios.post('/bills', {
+      name: name.value,
+      description: description.value,
+      amount: amount.value,
+      dueDate: dueDate.value,
+      category: category.value
+    });
+    name.value = '';
+    description.value = '';
+    amount.value = 0;
+    dueDate.value = '';
+    category.value = 'utilities';
+    emit('added');
+    error.value = null;
+  } catch (err) {
+    error.value = err.message;
+  } finally {
+    loading.value = false;
+  }
+};
+</script>
+
+<style scoped>
+form {
+  margin-bottom: 20px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+input,
+select,
+button {
+  padding: 5px;
+}
+.error {
+  color: red;
+  margin-top: 5px;
+}
+</style>

--- a/frontend/src/components/BillTable.vue
+++ b/frontend/src/components/BillTable.vue
@@ -1,0 +1,145 @@
+<template>
+  <div>
+    <div class="controls">
+      <input v-model="search" placeholder="Search" />
+      <select v-model="category">
+        <option value="">All Categories</option>
+        <option value="utilities">Utilities</option>
+        <option value="subscriptions">Subscriptions</option>
+        <option value="taxes">Taxes</option>
+        <option value="others">Others</option>
+      </select>
+      <select v-model="status">
+        <option value="">All Statuses</option>
+        <option value="paid">Paid</option>
+        <option value="pending">Pending</option>
+        <option value="overdue">Overdue</option>
+      </select>
+    </div>
+
+    <div v-if="loading">Loading...</div>
+    <div v-else-if="error" class="error">{{ error }}</div>
+
+    <table v-else>
+      <thead>
+        <tr>
+          <th @click="changeSort('name')">Name</th>
+          <th>Description</th>
+          <th @click="changeSort('category')">Category</th>
+          <th @click="changeSort('dueDate')">Due Date</th>
+          <th>Amount</th>
+          <th>Status</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="bill in bills" :key="bill.id">
+          <td>{{ bill.name }}</td>
+          <td>{{ bill.description }}</td>
+          <td>{{ bill.category }}</td>
+          <td>{{ formatDate(bill.dueDate) }}</td>
+          <td>{{ bill.amount.toFixed(2) }}</td>
+          <td :class="'status-' + bill.status">{{ bill.status }}</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div class="pagination">
+      <button @click="prev" :disabled="page === 1">Prev</button>
+      <span>{{ page }} / {{ totalPages }}</span>
+      <button @click="next" :disabled="page === totalPages">Next</button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, watch, onMounted, computed } from 'vue';
+import axios from 'axios';
+
+const bills = ref([]);
+const total = ref(0);
+const page = ref(1);
+const limit = 10;
+const search = ref('');
+const category = ref('');
+const status = ref('');
+const sort = ref('dueDate');
+const loading = ref(false);
+const error = ref(null);
+
+const fetchBills = async () => {
+  loading.value = true;
+  try {
+    const { data } = await axios.get('/bills', {
+      params: {
+        page: page.value,
+        limit,
+        sort: sort.value,
+        search: search.value,
+        category: category.value,
+        status: status.value
+      }
+    });
+    bills.value = data.data;
+    total.value = data.total;
+    error.value = null;
+  } catch (err) {
+    error.value = err.message;
+  } finally {
+    loading.value = false;
+  }
+};
+
+watch([page, search, category, status, sort], fetchBills);
+onMounted(fetchBills);
+
+const totalPages = computed(() => Math.ceil(total.value / limit) || 1);
+
+function prev() {
+  if (page.value > 1) page.value--;
+}
+function next() {
+  if (page.value < totalPages.value) page.value++;
+}
+function changeSort(field) {
+  sort.value = field;
+}
+function formatDate(date) {
+  return new Date(date).toLocaleDateString();
+}
+</script>
+
+<style scoped>
+.controls {
+  margin-bottom: 10px;
+}
+.error {
+  color: red;
+}
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+th,
+td {
+  padding: 6px 8px;
+  border: 1px solid #ccc;
+}
+th {
+  cursor: pointer;
+}
+.status-paid {
+  color: green;
+}
+.status-pending {
+  color: orange;
+}
+.status-overdue {
+  color: red;
+}
+.pagination {
+  margin-top: 10px;
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+}
+</style>

--- a/frontend/src/components/SummaryWidget.vue
+++ b/frontend/src/components/SummaryWidget.vue
@@ -1,0 +1,46 @@
+<template>
+  <div class="summary">
+    <div v-if="loading">Loading summary...</div>
+    <div v-else-if="error" class="error">{{ error }}</div>
+    <div v-else>
+      <span>Paid: {{ summary.paid.toFixed(2) }}</span>
+      <span>Pending: {{ summary.pending.toFixed(2) }}</span>
+      <span>Overdue: {{ summary.overdue.toFixed(2) }}</span>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue';
+import axios from 'axios';
+
+const summary = ref({ paid: 0, pending: 0, overdue: 0 });
+const loading = ref(false);
+const error = ref(null);
+
+const fetchSummary = async () => {
+  loading.value = true;
+  try {
+    const { data } = await axios.get('/bills/summary');
+    summary.value = data;
+    error.value = null;
+  } catch (err) {
+    error.value = err.message;
+  } finally {
+    loading.value = false;
+  }
+};
+
+onMounted(fetchSummary);
+</script>
+
+<style scoped>
+.summary {
+  display: flex;
+  gap: 15px;
+  margin-bottom: 20px;
+}
+.error {
+  color: red;
+}
+</style>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,0 +1,4 @@
+import { createApp } from 'vue';
+import App from './App.vue';
+
+createApp(App).mount('#app');

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+
+export default defineConfig({
+  plugins: [vue()],
+  server: {
+    port: 5173
+  }
+});

--- a/src/controllers/billController.js
+++ b/src/controllers/billController.js
@@ -4,12 +4,13 @@ import {
   addBill,
   updateBill,
   deleteBill,
-  getUpcomingBills
+  getUpcomingBills,
+  getMonthlySummary
 } from '../services/billService.js';
 
 export const getAll = (req, res, next) => {
   try {
-    res.json(listBills());
+    res.json(listBills(req.query));
   } catch (err) {
     next(err);
   }
@@ -57,6 +58,14 @@ export const remove = (req, res, next) => {
 export const upcoming = (req, res, next) => {
   try {
     res.json(getUpcomingBills());
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const summary = (req, res, next) => {
+  try {
+    res.json(getMonthlySummary());
   } catch (err) {
     next(err);
   }

--- a/src/db/mockDB.js
+++ b/src/db/mockDB.js
@@ -3,15 +3,19 @@ const bills = [
   {
     id: '1',
     name: 'Electricity',
+    description: 'Monthly power bill',
+    category: 'utilities',
     dueDate: new Date(Date.now() + 2 * 24 * 60 * 60 * 1000).toISOString(),
     amount: 60.5,
     status: 'pending'
   },
   {
     id: '2',
-    name: 'Water',
+    name: 'Streaming Service',
+    description: 'Video subscription',
+    category: 'subscriptions',
     dueDate: new Date(Date.now() + 5 * 24 * 60 * 60 * 1000).toISOString(),
-    amount: 30,
+    amount: 12.99,
     status: 'pending'
   }
 ];

--- a/src/routes/billRoutes.js
+++ b/src/routes/billRoutes.js
@@ -5,6 +5,7 @@ const router = Router();
 
 router.get('/', controller.getAll);
 router.get('/upcoming', controller.upcoming);
+router.get('/summary', controller.summary);
 router.get('/:id', controller.getById);
 router.post('/', controller.create);
 router.put('/:id', controller.update);


### PR DESCRIPTION
## Summary
- implement overdue bill auto-updates, filtering, pagination, and monthly summary
- expose `/bills/summary` endpoint
- update mock DB with categories and descriptions
- create Vue 3 + Vite frontend dashboard

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6843bd6e1d48832f81fbb31708dffd38