### PR TITLE
🔧 Centralized Axios config + CORS using environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Node modules
+node_modules/
+
+# Environment variables
+.env
+.env.*
+
+# Logs
+npm-debug.log*
+

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,0 +1,7 @@
+import axios from 'axios';
+
+const api = axios.create({
+  baseURL: import.meta.env.VITE_API_URL
+});
+
+export default api;

--- a/frontend/src/components/BillForm.vue
+++ b/frontend/src/components/BillForm.vue
@@ -17,7 +17,7 @@
 
 <script setup>
 import { ref } from 'vue';
-import axios from 'axios';
+import api from '../api.js';
 
 const emit = defineEmits(['added']);
 
@@ -32,7 +32,7 @@ const error = ref(null);
 const submit = async () => {
   loading.value = true;
   try {
-    await axios.post('/bills', {
+    await api.post('/bills', {
       name: name.value,
       description: description.value,
       amount: amount.value,

--- a/frontend/src/components/BillTable.vue
+++ b/frontend/src/components/BillTable.vue
@@ -53,7 +53,7 @@
 
 <script setup>
 import { ref, watch, onMounted, computed } from 'vue';
-import axios from 'axios';
+import api from '../api.js';
 
 const bills = ref([]);
 const total = ref(0);
@@ -69,7 +69,7 @@ const error = ref(null);
 const fetchBills = async () => {
   loading.value = true;
   try {
-    const { data } = await axios.get('/bills', {
+    const { data } = await api.get('/bills', {
       params: {
         page: page.value,
         limit,

--- a/frontend/src/components/SummaryWidget.vue
+++ b/frontend/src/components/SummaryWidget.vue
@@ -12,7 +12,7 @@
 
 <script setup>
 import { ref, onMounted } from 'vue';
-import axios from 'axios';
+import api from '../api.js';
 
 const summary = ref({ paid: 0, pending: 0, overdue: 0 });
 const loading = ref(false);
@@ -21,7 +21,7 @@ const error = ref(null);
 const fetchSummary = async () => {
   loading.value = true;
   try {
-    const { data } = await axios.get('/bills/summary');
+    const { data } = await api.get('/bills/summary');
     summary.value = data;
     error.value = null;
   } catch (err) {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
   "dependencies": {
     "express": "^4.18.2",
     "uuid": "^9.0.0",
-    "node-cron": "^3.0.3"
+    "node-cron": "^3.0.3",
+    "cors": "^2.8.5",
+    "dotenv": "^16.3.1"
   },
   "devDependencies": {
     "nodemon": "^3.0.2"

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,16 @@
 import express from 'express';
+import cors from 'cors';
+import dotenv from 'dotenv';
 import billRoutes from './routes/billRoutes.js';
 import logger from './middleware/logger.js';
 import errorHandler from './middleware/errorHandler.js';
 import './reminder.js';
 
+dotenv.config();
+
 const app = express();
 app.use(express.json());
+app.use(cors({ origin: process.env.FRONTEND_URL }));
 app.use(logger);
 
 app.use('/bills', billRoutes);


### PR DESCRIPTION
## Summary
- configure CORS with dotenv-driven frontend URL
- centralize Axios configuration in `frontend/src/api.js`
- update components to use the shared api instance
- ignore env files and node_modules

## Testing
- `node src/index.js` *(fails: Cannot find package 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6843c72859c8832fbd66712fa92d7822