### PR TITLE
🧭 Vuetify Tabbed Navigation UI

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,10 +11,13 @@
     "axios": "^1.6.2",
     "vue": "^3.3.4",
     "vue-router": "^4.2.5",
-    "chart.js": "^4.4.0"
+    "chart.js": "^4.4.0",
+    "vuetify": "^3.3.7",
+    "@mdi/font": "^7.3.67"
   },
   "devDependencies": {
     "vite": "^4.4.9",
-    "@vitejs/plugin-vue": "^4.2.3"
+    "@vitejs/plugin-vue": "^4.2.3",
+    "vite-plugin-vuetify": "^1.0.2"
   }
 }

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,20 +1,59 @@
 <template>
-  <div class="container">
-    <h1>Bill Tracker Dashboard</h1>
-    <nav class="nav">
-      <router-link to="/">Dashboard</router-link>
-      <router-link to="/analytics">Analytics</router-link>
-    </nav>
-    <router-view @notify="showToast"></router-view>
-    <div v-if="toast" class="toast">{{ toast }}</div>
-  </div>
+  <v-app>
+    <v-container class="container">
+      <h1>Bill Tracker Dashboard</h1>
+      <v-tabs v-model="tab" grow @update:modelValue="navigate">
+        <v-tab value="/">Dashboard</v-tab>
+        <v-tab value="/history">History</v-tab>
+        <v-tab value="/analytics">Analytics</v-tab>
+      </v-tabs>
+      <v-tabs-items v-model="tab">
+        <v-tab-item value="/">
+          <router-view v-slot="{ Component }" v-if="tab === '/'">
+            <component :is="Component" @notify="showToast" />
+          </router-view>
+        </v-tab-item>
+        <v-tab-item value="/history">
+          <router-view v-slot="{ Component }" v-if="tab === '/history'">
+            <component :is="Component" @notify="showToast" />
+          </router-view>
+        </v-tab-item>
+        <v-tab-item value="/analytics">
+          <router-view v-slot="{ Component }" v-if="tab === '/analytics'">
+            <component :is="Component" @notify="showToast" />
+          </router-view>
+        </v-tab-item>
+      </v-tabs-items>
+      <div v-if="toast" class="toast">{{ toast }}</div>
+    </v-container>
+  </v-app>
 </template>
 
 <script setup>
-import { ref } from 'vue';
+import { ref, watch } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
 
 const toast = ref('');
 let timer;
+const tab = ref('/');
+const route = useRoute();
+const router = useRouter();
+
+watch(
+  () => route.path,
+  (val) => {
+    if (val.startsWith('/analytics')) tab.value = '/analytics';
+    else if (val.startsWith('/history')) tab.value = '/history';
+    else tab.value = '/';
+  },
+  { immediate: true }
+);
+
+function navigate(value) {
+  if (value !== route.path) {
+    router.push(value);
+  }
+}
 
 function showToast(msg) {
   toast.value = msg;
@@ -29,11 +68,6 @@ function showToast(msg) {
   margin: auto;
   padding: 20px;
   font-family: Arial, Helvetica, sans-serif;
-}
-.nav {
-  display: flex;
-  gap: 10px;
-  margin-bottom: 15px;
 }
 .toast {
   position: fixed;

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,5 +1,15 @@
 import { createApp } from 'vue';
 import App from './App.vue';
 import router from './router/index.js';
+import 'vuetify/styles';
+import { createVuetify } from 'vuetify';
+import * as components from 'vuetify/components';
+import * as directives from 'vuetify/directives';
+import '@mdi/font/css/materialdesignicons.css';
 
-createApp(App).use(router).mount('#app');
+const vuetify = createVuetify({
+  components,
+  directives
+});
+
+createApp(App).use(router).use(vuetify).mount('#app');

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -5,7 +5,7 @@ import Analytics from '../views/Analytics.vue';
 
 const routes = [
   { path: '/', component: Dashboard },
-  { path: '/history/:name', component: PaymentHistory, props: true },
+  { path: '/history/:name?', component: PaymentHistory, props: true },
   { path: '/analytics', component: Analytics }
 ];
 

--- a/frontend/src/views/PaymentHistory.vue
+++ b/frontend/src/views/PaymentHistory.vue
@@ -1,27 +1,30 @@
 <template>
   <div>
-    <h2>Payment History - {{ name }}</h2>
+    <h2>Payment History<span v-if="name"> - {{ name }}</span></h2>
     <router-link to="/">Back</router-link>
-    <div v-if="loading">Loading...</div>
-    <div v-else-if="error" class="error">{{ error }}</div>
-    <table v-else>
-      <thead>
-        <tr>
-          <th>Bill Name</th>
-          <th>Amount</th>
-          <th>Due Date</th>
-          <th>Paid Date</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr v-for="p in payments" :key="p.paidDate">
-          <td>{{ p.name }}</td>
-          <td>{{ p.amount.toFixed(2) }}</td>
-          <td>{{ format(p.dueDate) }}</td>
-          <td>{{ format(p.paidDate) }}</td>
-        </tr>
-      </tbody>
-    </table>
+    <div v-if="!name" class="info">Select a bill from the dashboard to view history.</div>
+    <div v-else>
+      <div v-if="loading">Loading...</div>
+      <div v-else-if="error" class="error">{{ error }}</div>
+      <table v-else>
+        <thead>
+          <tr>
+            <th>Bill Name</th>
+            <th>Amount</th>
+            <th>Due Date</th>
+            <th>Paid Date</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="p in payments" :key="p.paidDate">
+            <td>{{ p.name }}</td>
+            <td>{{ p.amount.toFixed(2) }}</td>
+            <td>{{ format(p.dueDate) }}</td>
+            <td>{{ format(p.paidDate) }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
   </div>
 </template>
 
@@ -39,6 +42,7 @@ function format(d) {
 }
 
 const fetchData = async () => {
+  if (!props.name) return;
   loading.value = true;
   try {
     const { data } = await api.get(`/payments/${props.name}`);
@@ -57,5 +61,8 @@ onMounted(fetchData);
 <style scoped>
 .error {
   color: red;
+}
+.info {
+  margin-top: 10px;
 }
 </style>

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,8 +1,9 @@
 import { defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
+import vuetify from 'vite-plugin-vuetify';
 
 export default defineConfig({
-  plugins: [vue()],
+  plugins: [vue(), vuetify({ autoImport: true })],
   server: {
     port: 5173
   }


### PR DESCRIPTION
## Summary
- add Vuetify dependencies
- configure Vite to use Vuetify plugin
- setup Vuetify instance in `main.js`
- convert app navigation to `<v-tabs>` driven tabs
- allow `PaymentHistory` page with optional name parameter

## Testing
- `npm test` *(fails: Missing script)*
- `npm --prefix frontend run build` *(fails: vite not found)*
- `npm --prefix frontend install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6843cfbfed48832f829cf3841822f00f