### PR TITLE
💳 Payment Provider field with filtering support

### DIFF
--- a/frontend/src/components/BillForm.vue
+++ b/frontend/src/components/BillForm.vue
@@ -4,6 +4,10 @@
     <input v-model="description" placeholder="Description" />
     <input type="number" v-model.number="amount" placeholder="Amount" required />
     <input type="date" v-model="dueDate" required />
+    <select v-model="paymentProvider">
+      <option disabled value="">Payment Provider</option>
+      <option v-for="p in providers" :key="p" :value="p">{{ p }}</option>
+    </select>
     <select v-model="category">
       <option value="utilities">Utilities</option>
       <option value="subscriptions">Subscriptions</option>
@@ -28,6 +32,15 @@ const name = ref('');
 const description = ref('');
 const amount = ref(0);
 const dueDate = ref('');
+const providers = [
+  'Visa',
+  'Mastercard',
+  'MercadoPago',
+  'Google Play',
+  'MODO',
+  'PayPal'
+];
+const paymentProvider = ref(providers[0]);
 const category = ref('utilities');
 const autoRenew = ref(false);
 const loading = ref(false);
@@ -41,6 +54,7 @@ const submit = async () => {
       description: description.value,
       amount: amount.value,
       dueDate: dueDate.value,
+      paymentProvider: paymentProvider.value,
       category: category.value,
       autoRenew: autoRenew.value
     });
@@ -48,6 +62,7 @@ const submit = async () => {
     description.value = '';
     amount.value = 0;
     dueDate.value = '';
+    paymentProvider.value = providers[0];
     category.value = 'utilities';
     autoRenew.value = false;
     emit('added');

--- a/frontend/src/components/BillTable.vue
+++ b/frontend/src/components/BillTable.vue
@@ -15,6 +15,10 @@
         <option value="pending">Pending</option>
         <option value="overdue">Overdue</option>
       </select>
+      <select v-model="paymentProvider">
+        <option value="">All Providers</option>
+        <option v-for="p in providers" :key="p" :value="p">{{ p }}</option>
+      </select>
     </div>
 
     <div v-if="loading">Loading...</div>
@@ -28,6 +32,7 @@
           <th @click="changeSort('category')">Category</th>
           <th @click="changeSort('dueDate')">Due Date</th>
           <th>Amount</th>
+          <th>Payment Provider</th>
           <th>Status</th>
           <th>Auto Renew</th>
           <th>Actions</th>
@@ -40,6 +45,7 @@
           <td>{{ bill.category }}</td>
           <td>{{ formatDate(bill.dueDate) }}</td>
           <td>{{ bill.amount.toFixed(2) }}</td>
+          <td>{{ providerIcon(bill.paymentProvider) }} {{ bill.paymentProvider }}</td>
           <td :class="'status-' + bill.status">{{ bill.status }}</td>
           <td>{{ bill.autoRenew ? 'Yes' : 'No' }}</td>
           <td>
@@ -91,6 +97,15 @@ const limit = 10;
 const search = ref('');
 const category = ref('');
 const status = ref('');
+const providers = [
+  'Visa',
+  'Mastercard',
+  'MercadoPago',
+  'Google Play',
+  'MODO',
+  'PayPal'
+];
+const paymentProvider = ref('');
 const sort = ref('dueDate');
 const loading = ref(false);
 const error = ref(null);
@@ -107,7 +122,8 @@ const fetchBills = async () => {
         sort: sort.value,
         search: search.value,
         category: category.value,
-        status: status.value
+        status: status.value,
+        paymentProvider: paymentProvider.value
       }
     });
     bills.value = data.data;
@@ -120,8 +136,14 @@ const fetchBills = async () => {
   }
 };
 
-watch([page, search, category, status, sort], fetchBills);
+watch([page, search, category, status, paymentProvider, sort], fetchBills);
 onMounted(fetchBills);
+
+watch(paymentProvider, (val) => {
+  router.replace({
+    query: { ...router.currentRoute.value.query, paymentProvider: val || undefined }
+  });
+});
 
 const totalPages = computed(() => Math.ceil(total.value / limit) || 1);
 
@@ -136,6 +158,18 @@ function changeSort(field) {
 }
 function formatDate(date) {
   return new Date(date).toLocaleDateString();
+}
+
+function providerIcon(name) {
+  const icons = {
+    Visa: '💳',
+    Mastercard: '💳',
+    MercadoPago: '🤑',
+    'Google Play': '📱',
+    MODO: '🏦',
+    PayPal: '💲'
+  };
+  return icons[name] || '';
 }
 
 function edit(bill) {

--- a/frontend/src/components/EditBillForm.vue
+++ b/frontend/src/components/EditBillForm.vue
@@ -5,6 +5,9 @@
       <input v-model="description" placeholder="Description" />
       <input type="number" v-model.number="amount" placeholder="Amount" required />
       <input type="date" v-model="dueDate" required />
+      <select v-model="paymentProvider">
+        <option v-for="p in providers" :key="p" :value="p">{{ p }}</option>
+      </select>
       <select v-model="category">
         <option value="utilities">Utilities</option>
         <option value="subscriptions">Subscriptions</option>
@@ -37,8 +40,17 @@ const name = ref('');
 const description = ref('');
 const amount = ref(0);
 const dueDate = ref('');
+const providers = [
+  'Visa',
+  'Mastercard',
+  'MercadoPago',
+  'Google Play',
+  'MODO',
+  'PayPal'
+];
 const category = ref('utilities');
 const status = ref('pending');
+const paymentProvider = ref(providers[0]);
 const autoRenew = ref(false);
 const loading = ref(false);
 const error = ref(null);
@@ -51,6 +63,7 @@ const setFields = (b) => {
   dueDate.value = b.dueDate.substring(0,10);
   category.value = b.category;
   status.value = b.status;
+  paymentProvider.value = b.paymentProvider || providers[0];
   autoRenew.value = b.autoRenew || false;
 };
 
@@ -68,6 +81,7 @@ const submit = async () => {
       description: description.value,
       amount: amount.value,
       dueDate: dueDate.value,
+      paymentProvider: paymentProvider.value,
       category: category.value,
       status: status.value,
       autoRenew: autoRenew.value

--- a/src/db/mockDB.js
+++ b/src/db/mockDB.js
@@ -8,7 +8,8 @@ const bills = [
     dueDate: new Date(Date.now() + 2 * 24 * 60 * 60 * 1000).toISOString(),
     amount: 60.5,
     status: 'pending',
-    autoRenew: false
+    autoRenew: false,
+    paymentProvider: 'Visa'
   },
   {
     id: '2',
@@ -18,7 +19,8 @@ const bills = [
     dueDate: new Date(Date.now() + 5 * 24 * 60 * 60 * 1000).toISOString(),
     amount: 12.99,
     status: 'pending',
-    autoRenew: true
+    autoRenew: true,
+    paymentProvider: 'Mastercard'
   },
   {
     id: '3',
@@ -28,7 +30,41 @@ const bills = [
     dueDate: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
     amount: 9.99,
     status: 'pending',
-    autoRenew: true
+    autoRenew: true,
+    paymentProvider: 'MercadoPago'
+  },
+  {
+    id: '4',
+    name: 'Google Storage',
+    description: 'Cloud storage subscription',
+    category: 'subscriptions',
+    dueDate: new Date(Date.now() + 9 * 24 * 60 * 60 * 1000).toISOString(),
+    amount: 2.99,
+    status: 'pending',
+    autoRenew: true,
+    paymentProvider: 'Google Play'
+  },
+  {
+    id: '5',
+    name: 'Ride Share',
+    description: 'Local rides',
+    category: 'services',
+    dueDate: new Date(Date.now() + 3 * 24 * 60 * 60 * 1000).toISOString(),
+    amount: 15.5,
+    status: 'pending',
+    autoRenew: false,
+    paymentProvider: 'MODO'
+  },
+  {
+    id: '6',
+    name: 'Online Shopping',
+    description: 'Misc online purchases',
+    category: 'others',
+    dueDate: new Date(Date.now() + 4 * 24 * 60 * 60 * 1000).toISOString(),
+    amount: 40.0,
+    status: 'pending',
+    autoRenew: false,
+    paymentProvider: 'PayPal'
   }
 ];
 

--- a/src/services/billService.js
+++ b/src/services/billService.js
@@ -25,8 +25,15 @@ export const listBills = (query = {}) => {
   updateOverdueBills();
   let data = [...getBills()];
 
-  const { search, category, status, sort = 'dueDate', page = 1, limit = 10 } =
-    query;
+  const {
+    search,
+    category,
+    status,
+    paymentProvider,
+    sort = 'dueDate',
+    page = 1,
+    limit = 10
+  } = query;
 
   if (search) {
     const term = search.toLowerCase();
@@ -43,6 +50,14 @@ export const listBills = (query = {}) => {
 
   if (status) {
     data = data.filter((b) => b.status === status);
+  }
+
+  if (paymentProvider) {
+    data = data.filter(
+      (b) =>
+        b.paymentProvider &&
+        b.paymentProvider.toLowerCase() === paymentProvider.toLowerCase()
+    );
   }
 
   data.sort((a, b) => {
@@ -69,6 +84,7 @@ export const addBill = (data) => {
     id: uuidv4(),
     status: 'pending',
     autoRenew: false,
+    paymentProvider: data.paymentProvider || '',
     ...data
   };
   return addBillToDb(bill);
@@ -99,7 +115,8 @@ export const updateBill = (id, data) => {
       category: updated.category,
       dueDate: due.toISOString(),
       status: 'pending',
-      autoRenew: updated.autoRenew
+      autoRenew: updated.autoRenew,
+      paymentProvider: updated.paymentProvider
     };
     addBillToDb(newBill);
   }


### PR DESCRIPTION
## Summary
- support `paymentProvider` in backend bills
- filter bills by provider on GET `/bills`
- show provider column and filter in dashboard
- allow selecting provider in add/edit forms
- mockDB now includes sample providers

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6843d1f5a014832fa04afbe0480a9a1f