### PR TITLE
🎨 Full UI Migration to Vuetify 3

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,6 +1,7 @@
 <template>
   <v-app>
-    <v-container class="container">
+    <v-main>
+      <v-container class="container">
       <h1>Bill Tracker Dashboard</h1>
       <v-tabs v-model="tab" grow @update:modelValue="navigate">
         <v-tab value="/">Dashboard</v-tab>
@@ -25,7 +26,8 @@
         </v-tab-item>
       </v-tabs-items>
       <div v-if="toast" class="toast">{{ toast }}</div>
-    </v-container>
+      </v-container>
+    </v-main>
   </v-app>
 </template>
 

--- a/frontend/src/components/BillForm.vue
+++ b/frontend/src/components/BillForm.vue
@@ -1,25 +1,41 @@
 <template>
-  <form @submit.prevent="submit">
-    <input v-model="name" placeholder="Name" required />
-    <input v-model="description" placeholder="Description" />
-    <input type="number" v-model.number="amount" placeholder="Amount" required />
-    <input type="date" v-model="dueDate" required />
-    <select v-model="paymentProvider">
-      <option disabled value="">Payment Provider</option>
-      <option v-for="p in providers" :key="p" :value="p">{{ p }}</option>
-    </select>
-    <select v-model="category">
-      <option value="utilities">Utilities</option>
-      <option value="subscriptions">Subscriptions</option>
-      <option value="taxes">Taxes</option>
-      <option value="others">Others</option>
-    </select>
-    <label v-if="category === 'subscriptions'">
-      <input type="checkbox" v-model="autoRenew" /> Auto Renew
-    </label>
-    <button type="submit" :disabled="loading">Add</button>
-  </form>
-  <div v-if="error" class="error">{{ error }}</div>
+  <v-form @submit.prevent="submit" class="form">
+    <v-text-field v-model="name" label="Name" density="compact" required />
+    <v-text-field v-model="description" label="Description" density="compact" />
+    <v-text-field
+      v-model.number="amount"
+      label="Amount"
+      type="number"
+      density="compact"
+      required
+    />
+    <v-menu v-model="menu" :close-on-content-click="false" transition="scale-transition">
+      <template #activator="{ props }">
+        <v-text-field
+          v-model="dueDate"
+          label="Due Date"
+          readonly
+          v-bind="props"
+          density="compact"
+        />
+      </template>
+      <v-date-picker v-model="dueDate" @update:modelValue="menu = false" />
+    </v-menu>
+    <v-select
+      v-model="paymentProvider"
+      :items="providers"
+      label="Payment Provider"
+      density="compact"
+    />
+    <v-select v-model="category" :items="categories" label="Category" density="compact" />
+    <v-switch
+      v-if="category === 'subscriptions'"
+      v-model="autoRenew"
+      label="Auto Renew"
+    />
+    <v-btn type="submit" :loading="loading" color="primary" class="mt-2">Add</v-btn>
+  </v-form>
+  <v-alert v-if="error" type="error" dense class="mt-2">{{ error }}</v-alert>
 </template>
 
 <script setup>
@@ -32,6 +48,7 @@ const name = ref('');
 const description = ref('');
 const amount = ref(0);
 const dueDate = ref('');
+const menu = ref(false);
 const providers = [
   'Visa',
   'Mastercard',
@@ -41,6 +58,7 @@ const providers = [
   'PayPal'
 ];
 const paymentProvider = ref(providers[0]);
+const categories = ['utilities', 'subscriptions', 'taxes', 'others'];
 const category = ref('utilities');
 const autoRenew = ref(false);
 const loading = ref(false);
@@ -75,20 +93,4 @@ const submit = async () => {
 };
 </script>
 
-<style scoped>
-form {
-  margin-bottom: 20px;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 5px;
-}
-input,
-select,
-button {
-  padding: 5px;
-}
-.error {
-  color: red;
-  margin-top: 5px;
-}
-</style>
+

--- a/frontend/src/components/EditBillForm.vue
+++ b/frontend/src/components/EditBillForm.vue
@@ -1,32 +1,37 @@
 <template>
-  <div class="edit-form">
-    <form @submit.prevent="submit">
-      <input v-model="name" placeholder="Name" required />
-      <input v-model="description" placeholder="Description" />
-      <input type="number" v-model.number="amount" placeholder="Amount" required />
-      <input type="date" v-model="dueDate" required />
-      <select v-model="paymentProvider">
-        <option v-for="p in providers" :key="p" :value="p">{{ p }}</option>
-      </select>
-      <select v-model="category">
-        <option value="utilities">Utilities</option>
-        <option value="subscriptions">Subscriptions</option>
-        <option value="taxes">Taxes</option>
-        <option value="others">Others</option>
-      </select>
-      <select v-model="status">
-        <option value="pending">Pending</option>
-        <option value="paid">Paid</option>
-        <option value="overdue">Overdue</option>
-      </select>
-      <label v-if="category === 'subscriptions'">
-        <input type="checkbox" v-model="autoRenew" /> Auto Renew
-      </label>
-      <button type="submit" :disabled="loading">Save</button>
-      <button type="button" @click="emit('close')">Cancel</button>
-    </form>
-    <div v-if="error" class="error">{{ error }}</div>
-  </div>
+  <v-card class="pa-4 edit-form">
+    <v-form @submit.prevent="submit">
+      <v-text-field v-model="name" label="Name" density="compact" required />
+      <v-text-field v-model="description" label="Description" density="compact" />
+      <v-text-field
+        v-model.number="amount"
+        label="Amount"
+        type="number"
+        density="compact"
+        required
+      />
+      <v-menu v-model="menu" :close-on-content-click="false" transition="scale-transition">
+        <template #activator="{ props }">
+          <v-text-field v-model="dueDate" label="Due Date" readonly v-bind="props" density="compact" />
+        </template>
+        <v-date-picker v-model="dueDate" @update:modelValue="menu = false" />
+      </v-menu>
+      <v-select
+        v-model="paymentProvider"
+        :items="providers"
+        label="Payment Provider"
+        density="compact"
+      />
+      <v-select v-model="category" :items="categories" label="Category" density="compact" />
+      <v-select v-model="status" :items="statusOptions" label="Status" density="compact" />
+      <v-switch v-if="category === 'subscriptions'" v-model="autoRenew" label="Auto Renew" />
+      <div class="d-flex gap-2 mt-2">
+        <v-btn type="submit" :loading="loading" color="primary">Save</v-btn>
+        <v-btn type="button" @click="emit('close')">Cancel</v-btn>
+      </div>
+    </v-form>
+    <v-alert v-if="error" type="error" dense class="mt-2">{{ error }}</v-alert>
+  </v-card>
 </template>
 
 <script setup>
@@ -36,6 +41,7 @@ import api from '../api.js';
 const props = defineProps({ bill: Object });
 const emit = defineEmits(['updated', 'close']);
 
+const menu = ref(false);
 const name = ref('');
 const description = ref('');
 const amount = ref(0);
@@ -48,6 +54,8 @@ const providers = [
   'MODO',
   'PayPal'
 ];
+const categories = ['utilities', 'subscriptions', 'taxes', 'others'];
+const statusOptions = ['pending', 'paid', 'overdue'];
 const category = ref('utilities');
 const status = ref('pending');
 const paymentProvider = ref(providers[0]);
@@ -97,22 +105,4 @@ const submit = async () => {
 };
 </script>
 
-<style scoped>
-.edit-form {
-  margin-top: 10px;
-}
-form {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 5px;
-}
-input,
-select,
-button {
-  padding: 5px;
-}
-.error {
-  color: red;
-  margin-top: 5px;
-}
-</style>
+

--- a/frontend/src/components/SummaryWidget.vue
+++ b/frontend/src/components/SummaryWidget.vue
@@ -1,13 +1,17 @@
 <template>
-  <div class="summary">
-    <div v-if="loading">Loading summary...</div>
-    <div v-else-if="error" class="error">{{ error }}</div>
-    <div v-else>
-      <span>Paid: {{ summary.paid.toFixed(2) }}</span>
-      <span>Pending: {{ summary.pending.toFixed(2) }}</span>
-      <span>Overdue: {{ summary.overdue.toFixed(2) }}</span>
-    </div>
-  </div>
+  <v-row class="mb-4">
+    <v-col cols="12" v-if="loading">
+      <v-progress-linear indeterminate />
+    </v-col>
+    <v-col cols="12" v-else-if="error">
+      <v-alert type="error" dense>{{ error }}</v-alert>
+    </v-col>
+    <v-col cols="12" v-else class="d-flex gap-2">
+      <v-chip color="green">Paid: {{ summary.paid.toFixed(2) }}</v-chip>
+      <v-chip color="orange">Pending: {{ summary.pending.toFixed(2) }}</v-chip>
+      <v-chip color="red">Overdue: {{ summary.overdue.toFixed(2) }}</v-chip>
+    </v-col>
+  </v-row>
 </template>
 
 <script setup>
@@ -34,13 +38,4 @@ const fetchSummary = async () => {
 onMounted(fetchSummary);
 </script>
 
-<style scoped>
-.summary {
-  display: flex;
-  gap: 15px;
-  margin-bottom: 20px;
-}
-.error {
-  color: red;
-}
-</style>
+

--- a/frontend/src/views/Analytics.vue
+++ b/frontend/src/views/Analytics.vue
@@ -1,9 +1,13 @@
 <template>
-  <div>
+  <v-container>
     <h2>Analytics</h2>
-    <canvas id="categoryChart" width="400" height="200"></canvas>
-    <canvas id="monthChart" width="400" height="200"></canvas>
-  </div>
+    <v-card class="mb-4 pa-4">
+      <canvas id="categoryChart"></canvas>
+    </v-card>
+    <v-card class="pa-4">
+      <canvas id="monthChart"></canvas>
+    </v-card>
+  </v-container>
 </template>
 
 <script setup>
@@ -45,9 +49,4 @@ const buildCharts = async () => {
 onMounted(buildCharts);
 </script>
 
-<style scoped>
-canvas {
-  max-width: 400px;
-  margin-bottom: 20px;
-}
-</style>
+

--- a/frontend/src/views/PaymentHistory.vue
+++ b/frontend/src/views/PaymentHistory.vue
@@ -1,31 +1,24 @@
 <template>
-  <div>
+  <v-container>
     <h2>Payment History<span v-if="name"> - {{ name }}</span></h2>
-    <router-link to="/">Back</router-link>
+    <v-btn variant="text" to="/">Back</v-btn>
     <div v-if="!name" class="info">Select a bill from the dashboard to view history.</div>
     <div v-else>
-      <div v-if="loading">Loading...</div>
-      <div v-else-if="error" class="error">{{ error }}</div>
-      <table v-else>
-        <thead>
-          <tr>
-            <th>Bill Name</th>
-            <th>Amount</th>
-            <th>Due Date</th>
-            <th>Paid Date</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr v-for="p in payments" :key="p.paidDate">
-            <td>{{ p.name }}</td>
-            <td>{{ p.amount.toFixed(2) }}</td>
-            <td>{{ format(p.dueDate) }}</td>
-            <td>{{ format(p.paidDate) }}</td>
-          </tr>
-        </tbody>
-      </table>
+      <v-progress-linear v-if="loading" indeterminate />
+      <v-alert v-else-if="error" type="error" dense>{{ error }}</v-alert>
+      <v-data-table
+        v-else
+        :headers="headers"
+        :items="payments"
+        class="elevation-1"
+        hide-default-footer
+      >
+        <template #item.dueDate="{ item }">{{ format(item.dueDate) }}</template>
+        <template #item.paidDate="{ item }">{{ format(item.paidDate) }}</template>
+        <template #item.amount="{ item }">{{ item.amount.toFixed(2) }}</template>
+      </v-data-table>
     </div>
-  </div>
+  </v-container>
 </template>
 
 <script setup>
@@ -36,6 +29,13 @@ const props = defineProps({ name: String });
 const payments = ref([]);
 const loading = ref(false);
 const error = ref(null);
+
+const headers = [
+  { title: 'Bill Name', key: 'name' },
+  { title: 'Amount', key: 'amount' },
+  { title: 'Due Date', key: 'dueDate' },
+  { title: 'Paid Date', key: 'paidDate' }
+];
 
 function format(d) {
   return new Date(d).toLocaleDateString();
@@ -58,11 +58,4 @@ const fetchData = async () => {
 onMounted(fetchData);
 </script>
 
-<style scoped>
-.error {
-  color: red;
-}
-.info {
-  margin-top: 10px;
-}
-</style>
+


### PR DESCRIPTION
## Summary
- switch app layout to use `<v-main>`
- modernize Bill form with Vuetify fields and date pickers
- replace bill table with `<v-data-table>` and Vuetify controls
- update edit form, summary widget, history and analytics views with Vuetify components

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843d3a50e0c832fb71e9d408f6f9998