### PR TITLE
📝 Move Edit Bill form to modal dialog

### DIFF
--- a/frontend/src/components/BillTable.vue
+++ b/frontend/src/components/BillTable.vue
@@ -82,6 +82,7 @@
 
     <EditBillForm
       v-if="editingBill"
+      :key="editingBill.id"
       :bill="editingBill"
       @updated="onUpdated"
       @close="closeEdit"


### PR DESCRIPTION
## Summary
- present EditBillForm inside a `v-dialog` so editing uses a modal
- auto-open the dialog when a bill is provided and close via `close()` handler
- update BillTable to mount EditBillForm with a key for each bill

## Testing
- `npm test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_6843da3e57f8832f99d3671dac73250e