### PR TITLE
💾 Persist payment history with paidAt

### DIFF
--- a/frontend/src/views/PaymentHistory.vue
+++ b/frontend/src/views/PaymentHistory.vue
@@ -60,7 +60,7 @@
       hide-default-footer
     >
       <template #item.dueDate="{ item }">{{ format(item.dueDate) }}</template>
-      <template #item.paidDate="{ item }">{{ format(item.paidDate) }}</template>
+      <template #item.paidAt="{ item }">{{ format(item.paidAt) }}</template>
       <template #item.amount="{ item }">{{ item.amount.toFixed(2) }}</template>
     </v-data-table>
   </v-container>
@@ -93,7 +93,7 @@ const headers = [
   { title: 'Bill Name', key: 'name' },
   { title: 'Amount', key: 'amount' },
   { title: 'Due Date', key: 'dueDate' },
-  { title: 'Paid Date', key: 'paidDate' },
+  { title: 'Paid Date', key: 'paidAt' },
   { title: 'Provider', key: 'paymentProvider' },
   { title: 'Recurrence', key: 'recurrence' }
 ];
@@ -128,10 +128,10 @@ const filteredPayments = computed(() => {
       (p) => p.paymentProvider && p.paymentProvider === provider.value
     );
   if (startDate.value)
-    data = data.filter((p) => new Date(p.paidDate) >= new Date(startDate.value));
+    data = data.filter((p) => new Date(p.paidAt) >= new Date(startDate.value));
   if (endDate.value)
-    data = data.filter((p) => new Date(p.paidDate) <= new Date(endDate.value));
-  return data;
+    data = data.filter((p) => new Date(p.paidAt) <= new Date(endDate.value));
+  return data.sort((a, b) => new Date(b.paidAt) - new Date(a.paidAt));
 });
 </script>
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,6 +18,7 @@ model Bill {
   paymentProvider String?
   autoRenew       Boolean  @default(false)
   recurrence      String   @default("none")
+  paidAt          DateTime?
   createdAt       DateTime @default(now())
   updatedAt       DateTime @updatedAt
 }

--- a/src/services/billService.js
+++ b/src/services/billService.js
@@ -65,7 +65,11 @@ export const updateBill = async (id, data) => {
   const existing = await prisma.bill.findUnique({ where: { id } });
   if (!existing) return null;
 
-  const updated = await prisma.bill.update({ where: { id }, data });
+  const updateData = { ...data };
+  if (data.status === 'paid' && existing.status !== 'paid') {
+    updateData.paidAt = new Date();
+  }
+  const updated = await prisma.bill.update({ where: { id }, data: updateData });
   let newBill = null;
 
   if (
@@ -112,7 +116,7 @@ export const updateBill = async (id, data) => {
       name: updated.name,
       amount: updated.amount,
       dueDate: updated.dueDate,
-      paidDate: new Date().toISOString(),
+      paidAt: new Date().toISOString(),
       paymentProvider: updated.paymentProvider,
       recurrence: updated.recurrence || 'none'
     });

--- a/src/services/paymentService.js
+++ b/src/services/paymentService.js
@@ -6,5 +6,9 @@ import {
 
 export const addPayment = (payment) => addPaymentToDb(payment);
 
-export const listPayments = (name) =>
-  name ? getPaymentsByName(name) : getAllPayments();
+export const listPayments = (name) => {
+  const data = name ? getPaymentsByName(name) : getAllPayments();
+  return [...data].sort(
+    (a, b) => new Date(b.paidAt) - new Date(a.paidAt)
+  );
+};


### PR DESCRIPTION
## Summary
- add `paidAt` field to Prisma Bill model
- update bill service to store payment timestamp
- sort payments by payment date
- display paidAt in history view and sort descending

## Testing
- `npm install`
- `npx prisma generate` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6843e577f148832f8062a88791d27e50