### PR TITLE
🗃️ Refactor: Payment History now uses persistent DB

### DIFF
--- a/prisma/migrations/add-payment-table/migration.sql
+++ b/prisma/migrations/add-payment-table/migration.sql
@@ -1,0 +1,13 @@
+CREATE TABLE `Payment` (
+  `id` VARCHAR(191) NOT NULL PRIMARY KEY,
+  `billId` VARCHAR(191) NOT NULL,
+  `name` VARCHAR(191) NOT NULL,
+  `amount` DOUBLE NOT NULL,
+  `dueDate` DATETIME(3) NOT NULL,
+  `paidAt` DATETIME(3) NOT NULL,
+  `paymentProvider` VARCHAR(191),
+  `recurrence` VARCHAR(191) NOT NULL DEFAULT 'none',
+  `category` VARCHAR(191),
+  INDEX `Payment_billId_idx`(`billId`),
+  CONSTRAINT `Payment_billId_fkey` FOREIGN KEY (`billId`) REFERENCES `Bill`(`id`) ON DELETE CASCADE
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE=InnoDB;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,3 +22,19 @@ model Bill {
   createdAt       DateTime @default(now())
   updatedAt       DateTime @updatedAt
 }
+
+model Payment {
+  id              String   @id @default(uuid())
+  billId          String
+  name            String
+  amount          Float
+  dueDate         DateTime
+  paidAt          DateTime
+  paymentProvider String?
+  recurrence      String   @default("none")
+  category        String?
+
+  Bill Bill @relation(fields: [billId], references: [id], onDelete: Cascade)
+
+  @@index([billId])
+}

--- a/src/controllers/paymentController.js
+++ b/src/controllers/paymentController.js
@@ -1,8 +1,8 @@
 import { listPayments } from '../services/paymentService.js';
 
-export const history = (req, res, next) => {
+export const history = async (req, res, next) => {
   try {
-    res.json(listPayments(req.params.name));
+    res.json(await listPayments(req.params.name));
   } catch (err) {
     next(err);
   }

--- a/src/db/paymentsDB.js
+++ b/src/db/paymentsDB.js
@@ -1,11 +1,15 @@
-const payments = [];
+import prisma from './prismaClient.js';
 
-export const addPayment = (payment) => {
-  payments.push(payment);
-  return payment;
+export const addPayment = async (payment) => {
+  return prisma.payment.create({ data: payment });
 };
 
-export const getPaymentsByName = (name) =>
-  payments.filter((p) => p.name === name);
+export const getPaymentsByName = async (name) => {
+  return prisma.payment.findMany({
+    where: { name },
+    orderBy: { paidAt: 'desc' }
+  });
+};
 
-export const getAllPayments = () => payments;
+export const getAllPayments = async () =>
+  prisma.payment.findMany({ orderBy: { paidAt: 'desc' } });

--- a/src/services/billService.js
+++ b/src/services/billService.js
@@ -111,13 +111,14 @@ export const updateBill = async (id, data) => {
   }
 
   if (data.status === 'paid' && existing.status !== 'paid') {
-    addPayment({
+    await addPayment({
       billId: updated.id,
       name: updated.name,
       amount: updated.amount,
       dueDate: updated.dueDate,
       paidAt: new Date().toISOString(),
       paymentProvider: updated.paymentProvider,
+      category: updated.category,
       recurrence: updated.recurrence || 'none'
     });
   }

--- a/src/services/paymentService.js
+++ b/src/services/paymentService.js
@@ -4,11 +4,7 @@ import {
   getAllPayments
 } from '../db/paymentsDB.js';
 
-export const addPayment = (payment) => addPaymentToDb(payment);
+export const addPayment = async (payment) => addPaymentToDb(payment);
 
-export const listPayments = (name) => {
-  const data = name ? getPaymentsByName(name) : getAllPayments();
-  return [...data].sort(
-    (a, b) => new Date(b.paidAt) - new Date(a.paidAt)
-  );
-};
+export const listPayments = async (name) =>
+  name ? getPaymentsByName(name) : getAllPayments();


### PR DESCRIPTION
## Summary
- add `Payment` model to prisma schema
- migrate database schema with new payment table
- store payments via prisma instead of in-memory array
- fetch payments from DB ordered by `paidAt`
- update bill service to persist category on payment
- make payment controller async

## Testing
- `npm run migrate` *(fails: prisma not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843ea401e74832fa8744fcb88d98e61