### PR TITLE
🤖 Add Financial Chatbot Assistant

### DIFF
--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -73,6 +73,20 @@ Prepares data for pie and bar charts:
 
 ---
 
+## 6. Financial Chatbot Assistant
+
+**Purpose:**
+Provides quick answers to common billing questions through a chat interface.
+
+**Component:**
+- `Assistant.vue`
+
+**Logic:**
+- Parses keyword-based queries like "PayPal" or "last month".
+- Fetches matching bills and summarizes or lists the results.
+
+---
+
 > These frontend agents are reactive (computed or watcher-based) and run automatically based on state changes.
 
 ## 🛠 Development Notes

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -24,6 +24,12 @@
           title="Analytics"
           :active="route.path.startsWith('/analytics')"
         />
+        <v-list-item
+          to="/assistant"
+          prepend-icon="mdi-robot"
+          title="Assistant"
+          :active="route.path.startsWith('/assistant')"
+        />
       </v-list>
     </v-navigation-drawer>
 

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -2,11 +2,13 @@ import { createRouter, createWebHistory } from 'vue-router';
 import Dashboard from '../views/Dashboard.vue';
 import PaymentHistory from '../views/PaymentHistory.vue';
 import Analytics from '../views/Analytics.vue';
+import Assistant from '../views/Assistant.vue';
 
 const routes = [
   { path: '/', component: Dashboard },
   { path: '/history/:name?', component: PaymentHistory, props: true },
-  { path: '/analytics', component: Analytics }
+  { path: '/analytics', component: Analytics },
+  { path: '/assistant', component: Assistant }
 ];
 
 export default createRouter({

--- a/frontend/src/views/Assistant.vue
+++ b/frontend/src/views/Assistant.vue
@@ -1,0 +1,106 @@
+<template>
+  <v-container>
+    <h2>Assistant</h2>
+    <div class="chat-window">
+      <div
+        v-for="(msg, index) in messages"
+        :key="index"
+        :class="['bubble', msg.from]"
+      >
+        {{ msg.text }}
+      </div>
+    </div>
+    <v-text-field
+      v-model="input"
+      label="Ask a question"
+      density="compact"
+      append-inner-icon="mdi-send"
+      @click:append-inner="send"
+      @keyup.enter="send"
+    />
+  </v-container>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+import api from '../api.js';
+
+const messages = ref([{ from: 'bot', text: 'Hi! Ask me about your bills.' }]);
+const input = ref('');
+
+async function send() {
+  if (!input.value.trim()) return;
+  messages.value.push({ from: 'user', text: input.value });
+  const answer = await handleQuery(input.value);
+  messages.value.push({ from: 'bot', text: answer });
+  input.value = '';
+}
+
+async function handleQuery(q) {
+  const query = q.toLowerCase();
+  try {
+    if (query.includes('paypal')) {
+      const { data } = await api.get('/bills', {
+        params: { status: 'paid', paymentProvider: 'PayPal', limit: 1000 }
+      });
+      const bills = data.data;
+      return bills.length
+        ? bills.map((b) => `${b.name} - $${b.amount.toFixed(2)}`).join('\n')
+        : 'No PayPal payments found.';
+    }
+    if (query.includes('last month')) {
+      const { data } = await api.get('/bills', {
+        params: { status: 'paid', limit: 1000 }
+      });
+      const now = new Date();
+      const start = new Date(now.getFullYear(), now.getMonth() - 1, 1);
+      const end = new Date(now.getFullYear(), now.getMonth(), 1);
+      const bills = data.data.filter((b) => {
+        const d = new Date(b.paidAt || b.dueDate);
+        return d >= start && d < end;
+      });
+      const total = bills.reduce((sum, b) => sum + b.amount, 0);
+      return `You spent $${total.toFixed(2)} last month.`;
+    }
+    if (query.includes('paid subscriptions')) {
+      const { data } = await api.get('/bills', {
+        params: { status: 'paid', category: 'subscriptions', limit: 1000 }
+      });
+      const bills = data.data;
+      return bills.length
+        ? bills.map((b) => `${b.name} - $${b.amount.toFixed(2)}`).join('\n')
+        : 'No paid subscriptions found.';
+    }
+  } catch (err) {
+    return 'An error occurred while fetching data.';
+  }
+  return "Sorry, I didn't understand that.";
+}
+</script>
+
+<style scoped>
+.chat-window {
+  border: 1px solid #ccc;
+  min-height: 200px;
+  padding: 10px;
+  margin-bottom: 10px;
+  border-radius: 4px;
+  display: flex;
+  flex-direction: column;
+}
+.bubble {
+  max-width: 80%;
+  margin-bottom: 6px;
+  padding: 8px 12px;
+  border-radius: 8px;
+}
+.bubble.user {
+  background-color: #e0e0e0;
+  align-self: flex-end;
+}
+.bubble.bot {
+  background-color: #d1eaff;
+  align-self: flex-start;
+}
+</style>
+


### PR DESCRIPTION
## Summary
- create `Assistant.vue` for simple chat-based help
- add `/assistant` route
- show Assistant link in nav drawer
- document new *Financial Chatbot Assistant* agent

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6843f2b7f624832f8e923400ca6d2273