### PR TITLE
🧠 Add conversational memory to chatbot

### DIFF
--- a/frontend/src/views/Assistant.vue
+++ b/frontend/src/views/Assistant.vue
@@ -27,9 +27,18 @@ import api from '../api.js';
 
 const messages = ref([{ from: 'bot', text: 'Hi! Ask me about your bills.' }]);
 const input = ref('');
+const lastContext = ref({});
+const CONTEXT_TIMEOUT = 5 * 60 * 1000; // 5 minutes
+
+function clearStaleContext() {
+  if (lastContext.value.time && Date.now() - lastContext.value.time > CONTEXT_TIMEOUT) {
+    lastContext.value = {};
+  }
+}
 
 async function send() {
   if (!input.value.trim()) return;
+  clearStaleContext();
   messages.value.push({ from: 'user', text: input.value });
   const answer = await handleQuery(input.value);
   messages.value.push({ from: 'bot', text: answer });
@@ -37,44 +46,72 @@ async function send() {
 }
 
 async function handleQuery(q) {
-  const query = q.toLowerCase();
+  const context = parseQuery(q);
+  if (context.intent === 'reset') {
+    lastContext.value = {};
+    return 'Context cleared.';
+  }
+
+  const ctx = { ...lastContext.value, ...context, time: Date.now() };
+  lastContext.value = ctx;
+
+  const params = { limit: 1000 };
+  if (ctx.status) params.status = ctx.status;
+  if (ctx.provider) params.paymentProvider = ctx.provider;
+  if (ctx.category) params.category = ctx.category;
+
   try {
-    if (query.includes('paypal')) {
-      const { data } = await api.get('/bills', {
-        params: { status: 'paid', paymentProvider: 'PayPal', limit: 1000 }
-      });
-      const bills = data.data;
-      return bills.length
-        ? bills.map((b) => `${b.name} - $${b.amount.toFixed(2)}`).join('\n')
-        : 'No PayPal payments found.';
-    }
-    if (query.includes('last month')) {
-      const { data } = await api.get('/bills', {
-        params: { status: 'paid', limit: 1000 }
-      });
+    const { data } = await api.get('/bills', { params });
+    let bills = data.data;
+
+    if (ctx.date === 'last_month') {
       const now = new Date();
       const start = new Date(now.getFullYear(), now.getMonth() - 1, 1);
       const end = new Date(now.getFullYear(), now.getMonth(), 1);
-      const bills = data.data.filter((b) => {
+      bills = bills.filter((b) => {
         const d = new Date(b.paidAt || b.dueDate);
         return d >= start && d < end;
       });
-      const total = bills.reduce((sum, b) => sum + b.amount, 0);
-      return `You spent $${total.toFixed(2)} last month.`;
     }
-    if (query.includes('paid subscriptions')) {
-      const { data } = await api.get('/bills', {
-        params: { status: 'paid', category: 'subscriptions', limit: 1000 }
-      });
-      const bills = data.data;
+
+    if (ctx.intent === 'summary') {
+      const total = bills.reduce((sum, b) => sum + b.amount, 0);
+      let msg = `You spent $${total.toFixed(2)}`;
+      if (ctx.provider) msg += ` with ${ctx.provider}`;
+      if (ctx.date === 'last_month') msg += ' last month';
+      return msg + '.';
+    }
+
+    if (ctx.intent === 'list') {
       return bills.length
         ? bills.map((b) => `${b.name} - $${b.amount.toFixed(2)}`).join('\n')
-        : 'No paid subscriptions found.';
+        : 'No matching bills found.';
     }
   } catch (err) {
     return 'An error occurred while fetching data.';
   }
   return "Sorry, I didn't understand that.";
+}
+
+function parseQuery(q) {
+  const query = q.toLowerCase().trim();
+  const ctx = {};
+  if (/reset|clear/.test(query)) {
+    ctx.intent = 'reset';
+    return ctx;
+  }
+  if (query.includes('paypal')) ctx.provider = 'PayPal';
+  if (query.includes('last month') || query.includes('mes pasado')) ctx.date = 'last_month';
+  if (query.includes('paid subscriptions')) {
+    ctx.category = 'subscriptions';
+    ctx.status = 'paid';
+    ctx.intent = 'list';
+  }
+  if (/how much|total|cu[áa]nto/.test(query)) ctx.intent = 'summary';
+  if (!ctx.intent && (ctx.provider || ctx.category || ctx.date)) {
+    ctx.intent = lastContext.value.intent || 'list';
+  }
+  return ctx;
 }
 </script>
 


### PR DESCRIPTION
## Summary
- maintain `lastContext` inside `Assistant.vue` to remember previous queries
- parse user messages and merge with conversation context for follow-ups
- clear context on inactivity or when the user requests a reset

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6843f59b5024832fb2199b4c70ac77af