### PR TITLE
🤖 Add Financial Chatbot Assistant logic to backend

### DIFF
--- a/frontend/src/views/Assistant.vue
+++ b/frontend/src/views/Assistant.vue
@@ -19,6 +19,9 @@
       @click:append-inner="send"
       @keyup.enter="send"
     />
+    <v-btn color="primary" @click="resetConversation" class="mt-2">
+      Nueva conversación
+    </v-btn>
   </v-container>
 </template>
 
@@ -29,6 +32,15 @@ import api from '../api.js';
 const messages = ref([{ from: 'bot', text: 'Hi! Ask me about your bills.' }]);
 const input = ref('');
 const llmMode = ref(true);
+
+async function resetConversation() {
+  try {
+    await api.post('/chat/reset');
+  } catch (e) {
+    // ignore errors when resetting
+  }
+  messages.value = [{ from: 'bot', text: 'Hi! Ask me about your bills.' }];
+}
 
 async function send() {
   if (!input.value.trim()) return;

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import dotenv from 'dotenv';
 import billRoutes from './routes/billRoutes.js';
 import paymentRoutes from './routes/paymentRoutes.js';
 import assistantRoutes from './routes/assistantRoutes.js';
+import chatRoutes from './routes/chatRoutes.js';
 import logger from './middleware/logger.js';
 import errorHandler from './middleware/errorHandler.js';
 import './reminder.js';
@@ -24,6 +25,7 @@ app.use(logger);
 app.use('/bills', billRoutes);
 app.use('/payments', paymentRoutes);
 app.use('/assistant', assistantRoutes);
+app.use('/chat', chatRoutes);
 
 app.use(errorHandler);
 

--- a/src/prompts/financeAssistant.js
+++ b/src/prompts/financeAssistant.js
@@ -1,0 +1,35 @@
+const FINANCE_ASSISTANT_PROMPT = `
+You are a helpful personal finance assistant.
+
+The user will ask you questions about their spending. You'll receive:
+1. A user question in natural language (English or Spanish)
+2. A list of recent paid bills in JSON format, each containing:
+   - name
+   - amount
+   - paidAt
+   - paymentProvider
+   - recurrence
+
+Your job is to:
+- Understand the user's intent
+- Summarize the data in a friendly, clear response
+- Respond in the same language as the user
+- Never repeat raw JSON or technical values
+- Use bullet points or short lists when needed
+- Show currency values with 2 decimals
+
+If the query is about:
+- "Pagos por proveedor": summarize amounts by provider
+- "Suscripciones más caras": list top subscriptions sorted by amount
+- "Pagos este mes": filter by paidAt and calculate totals
+
+If the query is unclear: say “I didn’t understand. Can you rephrase?”
+
+Respond like:
+User: ¿Cuánto gasté con PayPal este mes?
+Assistant: Pagaste $25.98 con PayPal este mes.
+
+Now begin the conversation.
+`;
+
+export default FINANCE_ASSISTANT_PROMPT;

--- a/src/routes/chatRoutes.js
+++ b/src/routes/chatRoutes.js
@@ -1,0 +1,7 @@
+import { Router } from 'express';
+import { resetChat } from '../controllers/assistantController.js';
+
+const router = Router();
+router.post('/reset', resetChat);
+
+export default router;


### PR DESCRIPTION
## Summary
- create `financeAssistant.js` prompt with detailed instructions
- persist chat history and add reset endpoint
- wire up `/chat/reset` route
- support clearing conversation from the frontend

## Testing
- `npm install openai@^4.104.0 --silent`
- `npm list openai`

------
https://chatgpt.com/codex/tasks/task_e_68447f5c2ba4832fb4696177ee1009c9