### PR TITLE
🤖 Fix dashboard totals using backend summary

### DIFF
--- a/src/controllers/billController.js
+++ b/src/controllers/billController.js
@@ -5,7 +5,7 @@ import {
   updateBill,
   deleteBill,
   getUpcomingBills,
-  getMonthlySummary
+  getSummary
 } from '../services/billService.js';
 
 export const getAll = async (req, res, next) => {
@@ -64,7 +64,7 @@ export const upcoming = async (req, res, next) => {
 
 export const summary = async (req, res, next) => {
   try {
-    res.json(await getMonthlySummary());
+    res.json(await getSummary());
   } catch (err) {
     next(err);
   }

--- a/src/services/billService.js
+++ b/src/services/billService.js
@@ -154,3 +154,16 @@ export const getMonthlySummary = async () => {
   });
   return summary;
 };
+
+export const getSummary = async () => {
+  await updateOverdueBills();
+  const grouped = await prisma.bill.groupBy({
+    by: ['status'],
+    _sum: { amount: true }
+  });
+  const summary = { paid: 0, pending: 0, overdue: 0 };
+  grouped.forEach((g) => {
+    summary[g.status] = g._sum.amount ?? 0;
+  });
+  return summary;
+};

--- a/tests/bills.test.js
+++ b/tests/bills.test.js
@@ -85,7 +85,7 @@ describe('Bill endpoints', () => {
   });
 
   it('GET /bills/summary should return summary', async () => {
-    billService.getMonthlySummary.mockResolvedValue({ paid: 100, pending: 50, overdue: 0 });
+    billService.getSummary.mockResolvedValue({ paid: 100, pending: 50, overdue: 0 });
     const res = await request(app).get('/bills/summary');
     expect(res.status).toBe(200);
     expect(res.body.paid).toBe(100);


### PR DESCRIPTION
## Summary
- compute totals for all bills via `getSummary`
- update controller and tests to use new summary logic

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684487890cc8832f9fcf50e450849052