### PR TITLE
✅ Add unit tests for services and chatbot

### DIFF
--- a/tests/chatbot/assistantController.test.js
+++ b/tests/chatbot/assistantController.test.js
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const prismaMock = {
+  bill: {
+    findMany: vi.fn()
+  }
+};
+
+const openAiMock = {
+  chat: {
+    completions: { create: vi.fn() }
+  }
+};
+
+vi.mock('../../src/db/prismaClient.js', () => ({ default: prismaMock }));
+vi.mock('openai', () => ({ default: class { constructor() { return openAiMock; } } }));
+
+let controller;
+
+beforeEach(async () => {
+  vi.resetModules();
+  const module = await import('../../src/controllers/assistantController.js');
+  controller = module;
+});
+
+describe('ask handler', () => {
+  it('returns answer from openai', async () => {
+    prismaMock.bill.findMany.mockResolvedValue([]);
+    openAiMock.chat.completions.create.mockResolvedValue({ choices: [{ message: { content: 'ok' } }] });
+    const req = { body: { query: 'Hi' } };
+    const res = { json: vi.fn(), status: vi.fn(() => res) };
+    await controller.ask(req, res);
+    expect(res.json).toHaveBeenCalledWith({ answer: 'ok' });
+  });
+
+  it('returns 400 if no query', async () => {
+    const req = { body: {} };
+    const res = { json: vi.fn(), status: vi.fn(() => res) };
+    await controller.ask(req, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('handles openai error', async () => {
+    prismaMock.bill.findMany.mockResolvedValue([]);
+    openAiMock.chat.completions.create.mockRejectedValue(new Error('fail'));
+    const req = { body: { query: 'Hi' } };
+    const res = { json: vi.fn(), status: vi.fn(() => res) };
+    await controller.ask(req, res);
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ answer: "Sorry, I couldn't understand your question." });
+  });
+});
+
+describe('resetChat handler', () => {
+  it('responds with reset message', async () => {
+    const req = {};
+    const res = { json: vi.fn() };
+    await controller.resetChat(req, res);
+    expect(res.json).toHaveBeenCalledWith({ message: 'Chat reset' });
+  });
+});

--- a/tests/services/billService.test.js
+++ b/tests/services/billService.test.js
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+var prismaMock;
+vi.mock('../../src/db/prismaClient.js', () => {
+  prismaMock = {
+    bill: {
+      updateMany: vi.fn(),
+      count: vi.fn(),
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+      groupBy: vi.fn()
+    },
+    payment: { create: vi.fn() }
+  };
+  return { default: prismaMock };
+});
+var addPaymentMock;
+vi.mock('../../src/services/paymentService.js', () => {
+  addPaymentMock = vi.fn();
+  return { addPayment: addPaymentMock };
+});
+
+import * as billService from '../../src/services/billService.js';
+import { addPayment } from '../../src/services/paymentService.js';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe('listBills', () => {
+  it('returns paginated bills with filters', async () => {
+    prismaMock.bill.count.mockResolvedValue(1);
+    prismaMock.bill.findMany.mockResolvedValue([{ id: '1' }]);
+    const result = await billService.listBills({ category: 'utilities', page: 2, limit: 5 });
+    expect(prismaMock.bill.updateMany).toHaveBeenCalled();
+    expect(prismaMock.bill.findMany).toHaveBeenCalledWith({
+      where: { category: 'utilities' },
+      orderBy: { dueDate: 'asc' },
+      skip: 5,
+      take: 5
+    });
+    expect(result.total).toBe(1);
+    expect(result.page).toBe(2);
+    expect(result.data[0].id).toBe('1');
+  });
+});
+
+describe('addBill', () => {
+  it('creates bill with defaults', async () => {
+    prismaMock.bill.create.mockResolvedValue({ id: '1', status: 'pending' });
+    const data = { name: 'Test', amount: 5, dueDate: new Date() };
+    const bill = await billService.addBill(data);
+    expect(prismaMock.bill.create).toHaveBeenCalled();
+    expect(bill.id).toBe('1');
+  });
+});
+
+describe('getBillById', () => {
+  it('finds bill by id', async () => {
+    prismaMock.bill.findUnique.mockResolvedValue({ id: '1' });
+    const bill = await billService.getBillById('1');
+    expect(prismaMock.bill.findUnique).toHaveBeenCalledWith({ where: { id: '1' } });
+    expect(bill.id).toBe('1');
+  });
+});
+
+describe('updateBill', () => {
+  it('returns null when bill not found', async () => {
+    prismaMock.bill.findUnique.mockResolvedValue(null);
+    const res = await billService.updateBill('x', {});
+    expect(res).toBeNull();
+  });
+
+  it('creates payment and new bill when auto renew subscription paid', async () => {
+    const existing = { id: '1', status: 'pending', dueDate: new Date('2024-01-01'), category: 'subscriptions' };
+    const updated = { ...existing, status: 'paid', autoRenew: true, recurrence: 'monthly' };
+    prismaMock.bill.findUnique.mockResolvedValue(existing);
+    prismaMock.bill.update.mockResolvedValue(updated);
+    const newBill = { id: '2' };
+    prismaMock.bill.create.mockResolvedValue(newBill);
+    const result = await billService.updateBill('1', { status: 'paid' });
+    expect(addPayment).toHaveBeenCalled();
+    expect(prismaMock.bill.create).toHaveBeenCalled();
+    expect(result.newBill).toEqual(newBill);
+  });
+
+  it('only records payment when not subscription', async () => {
+    const existing = { id: '1', status: 'pending', dueDate: new Date(), category: 'utilities' };
+    const updated = { ...existing, status: 'paid', autoRenew: false };
+    prismaMock.bill.findUnique.mockResolvedValue(existing);
+    prismaMock.bill.update.mockResolvedValue(updated);
+    const result = await billService.updateBill('1', { status: 'paid' });
+    expect(addPayment).toHaveBeenCalled();
+    expect(result.newBill).toBeNull();
+  });
+});
+
+describe('deleteBill', () => {
+  it('deletes by id', async () => {
+    prismaMock.bill.delete.mockResolvedValue(true);
+    const res = await billService.deleteBill('1');
+    expect(prismaMock.bill.delete).toHaveBeenCalledWith({ where: { id: '1' } });
+    expect(res).toBe(true);
+  });
+});
+
+describe('getUpcomingBills', () => {
+  it('queries next 3 days', async () => {
+    const now = new Date('2024-01-01T00:00:00Z');
+    vi.setSystemTime(now);
+    prismaMock.bill.findMany.mockResolvedValue([]);
+    await billService.getUpcomingBills();
+    const limit = new Date(now.getTime() + 3 * 24 * 60 * 60 * 1000);
+    expect(prismaMock.bill.findMany).toHaveBeenCalledWith({ where: { dueDate: { gte: now, lte: limit } } });
+    vi.useRealTimers();
+  });
+});
+

--- a/tests/services/paymentService.test.js
+++ b/tests/services/paymentService.test.js
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+var dbMock;
+vi.mock('../../src/db/paymentsDB.js', () => {
+  dbMock = {
+    addPayment: vi.fn(),
+    getPaymentsByName: vi.fn(),
+    getAllPayments: vi.fn()
+  };
+  return {
+    addPayment: dbMock.addPayment,
+    getPaymentsByName: dbMock.getPaymentsByName,
+    getAllPayments: dbMock.getAllPayments
+  };
+});
+
+import * as paymentService from '../../src/services/paymentService.js';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe('addPayment', () => {
+  it('delegates to db', async () => {
+    dbMock.addPayment.mockResolvedValue({ id: '1' });
+    const res = await paymentService.addPayment({ amount: 1 });
+    expect(dbMock.addPayment).toHaveBeenCalledWith({ amount: 1 });
+    expect(res.id).toBe('1');
+  });
+});
+
+describe('listPayments', () => {
+  it('filters by name when provided', async () => {
+    dbMock.getPaymentsByName.mockResolvedValue([{ id: '1' }]);
+    const res = await paymentService.listPayments('Internet');
+    expect(dbMock.getPaymentsByName).toHaveBeenCalledWith('Internet');
+    expect(res.length).toBe(1);
+  });
+
+  it('returns all payments when no name', async () => {
+    dbMock.getAllPayments.mockResolvedValue([{ id: '2' }]);
+    const res = await paymentService.listPayments();
+    expect(dbMock.getAllPayments).toHaveBeenCalled();
+    expect(res[0].id).toBe('2');
+  });
+});

--- a/tests/utils/billUtils.test.js
+++ b/tests/utils/billUtils.test.js
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+var prismaMock;
+vi.mock('../../src/db/prismaClient.js', () => {
+  prismaMock = {
+    bill: {
+      updateMany: vi.fn(),
+      findMany: vi.fn(),
+      groupBy: vi.fn()
+    }
+  };
+  return { default: prismaMock };
+});
+import * as billService from '../../src/services/billService.js';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe('getMonthlySummary', () => {
+  it('sums amounts for current month', async () => {
+    const now = new Date('2024-01-15T00:00:00Z');
+    vi.setSystemTime(now);
+    prismaMock.bill.findMany.mockResolvedValue([
+      { status: 'paid', amount: 10 },
+      { status: 'pending', amount: 5 },
+      { status: 'overdue', amount: 2 }
+    ]);
+    const summary = await billService.getMonthlySummary();
+    expect(prismaMock.bill.updateMany).toHaveBeenCalled();
+    expect(summary).toEqual({ paid: 10, pending: 5, overdue: 2 });
+    vi.useRealTimers();
+  });
+});
+
+describe('getSummary', () => {
+  it('groups amounts by status', async () => {
+    prismaMock.bill.groupBy.mockResolvedValue([
+      { status: 'paid', _sum: { amount: 10 } },
+      { status: 'pending', _sum: { amount: 5 } }
+    ]);
+    const summary = await billService.getSummary();
+    expect(prismaMock.bill.updateMany).toHaveBeenCalled();
+    expect(summary.paid).toBe(10);
+    expect(summary.pending).toBe(5);
+    expect(summary.overdue).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add chatbot controller tests for success, missing query and error
- test bill service logic including auto-renew
- test payment service interactions
- test summary utilities

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68449128b748832fa00e654bac7ce16e