### PR TITLE
Enable history view for multiple invoices

### DIFF
--- a/frontend/src/components/BillTable.vue
+++ b/frontend/src/components/BillTable.vue
@@ -81,7 +81,7 @@
         >
           <v-icon>mdi-cancel</v-icon>
         </v-btn>
-        <v-btn icon v-if="item.category === 'subscriptions'" @click="history(item)">
+        <v-btn icon v-if="item.invoiceCount > 1" @click="history(item)">
           <v-icon>mdi-history</v-icon>
         </v-btn>
         <v-btn icon @click="edit(item)">


### PR DESCRIPTION
## Summary
- show history button when a service group has multiple invoices

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844ce429e78832fb265b345f60d2226