### PR TITLE
➕ Allow manual invoice creation from grouped view

### DIFF
--- a/frontend/src/components/BillTable.vue
+++ b/frontend/src/components/BillTable.vue
@@ -84,6 +84,9 @@
         <v-btn icon v-if="item.invoiceCount > 1" @click="history(item)">
           <v-icon>mdi-history</v-icon>
         </v-btn>
+        <v-btn icon v-if="!item.autoRenew" @click="newInvoice(item)">
+          <v-icon>mdi-plus</v-icon>
+        </v-btn>
         <v-btn icon @click="edit(item)">
           <v-icon>mdi-pencil</v-icon>
         </v-btn>
@@ -99,6 +102,12 @@
       @updated="onUpdated"
       @close="closeEdit"
     />
+    <ManualInvoiceForm
+      v-if="newBill"
+      :bill="newBill"
+      @created="onCreated"
+      @close="closeNew"
+    />
   </div>
 </template>
 
@@ -106,6 +115,7 @@
 import { ref, watch, onMounted, computed } from 'vue';
 import api from '../api.js';
 import EditBillForm from './EditBillForm.vue';
+import ManualInvoiceForm from './ManualInvoiceForm.vue';
 import { useRouter } from 'vue-router';
 
 const emit = defineEmits(['notify']);
@@ -132,6 +142,7 @@ const sort = ref('dueDate');
 const loading = ref(false);
 const error = ref(null);
 const editingBill = ref(null);
+const newBill = ref(null);
 const router = useRouter();
 
 const categoryOptions = [
@@ -275,6 +286,26 @@ function history(bill) {
       category: bill.category
     }
   });
+}
+
+function newInvoice(bill) {
+  newBill.value = {
+    name: bill.name,
+    category: bill.category,
+    paymentProvider: bill.paymentProvider,
+    recurrence: bill.recurrence || 'none',
+    amount: bill.amount,
+    dueDate: bill.dueDate.substring(0, 10),
+    status: 'pending'
+  };
+}
+
+function closeNew() {
+  newBill.value = null;
+}
+
+async function onCreated() {
+  await fetchBills();
 }
 
 function emitNotify(msg) {

--- a/frontend/src/components/ManualInvoiceForm.vue
+++ b/frontend/src/components/ManualInvoiceForm.vue
@@ -1,0 +1,122 @@
+<template>
+  <v-dialog v-model="dialog" max-width="500" @update:modelValue="val => !val && close()">
+    <v-card>
+      <v-form @submit.prevent="submit">
+        <v-card-title>\u2795 Nueva factura</v-card-title>
+        <v-card-text class="pt-0">
+          <v-text-field v-model="name" label="Name" density="compact" disabled />
+          <v-text-field v-model="category" label="Category" density="compact" disabled />
+          <v-text-field v-model="paymentProvider" label="Payment Provider" density="compact" disabled />
+          <v-select
+            v-model="recurrence"
+            :items="recurrenceOptions"
+            label="Recurrence"
+            density="compact"
+            disabled
+          />
+          <v-text-field
+            v-model.number="amount"
+            label="Amount"
+            type="number"
+            density="compact"
+            required
+          />
+          <v-menu v-model="menu" :close-on-content-click="false" transition="scale-transition">
+            <template #activator="{ props }">
+              <v-text-field
+                v-model="dueDate"
+                label="Due Date"
+                readonly
+                v-bind="props"
+                density="compact"
+              />
+            </template>
+            <v-date-picker v-model="dueDate" @update:modelValue="menu = false" />
+          </v-menu>
+          <v-select
+            v-model="status"
+            :items="statusOptions"
+            label="Status"
+            density="compact"
+          />
+          <v-alert v-if="error" type="error" dense class="mt-2">{{ error }}</v-alert>
+        </v-card-text>
+        <v-card-actions class="pt-0">
+          <v-spacer />
+          <v-btn text @click="close">Cancel</v-btn>
+          <v-btn type="submit" :loading="loading" color="primary">Save</v-btn>
+        </v-card-actions>
+      </v-form>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script setup>
+import { ref, watch } from 'vue';
+import api from '../api.js';
+
+const props = defineProps({ bill: Object });
+const emit = defineEmits(['created', 'close']);
+
+const dialog = ref(false);
+const menu = ref(false);
+
+const name = ref('');
+const category = ref('');
+const paymentProvider = ref('');
+const recurrenceOptions = ['none', 'weekly', 'monthly', 'bimonthly', 'yearly'];
+const recurrence = ref('none');
+const amount = ref(0);
+const dueDate = ref('');
+const statusOptions = ['pending', 'paid', 'overdue'];
+const status = ref('pending');
+const loading = ref(false);
+const error = ref(null);
+
+watch(
+  () => props.bill,
+  (b) => {
+    if (b) {
+      name.value = b.name;
+      category.value = b.category;
+      paymentProvider.value = b.paymentProvider || '';
+      recurrence.value = b.recurrence || 'none';
+      amount.value = b.amount || 0;
+      dueDate.value = (b.dueDate || '').substring(0, 10);
+      status.value = b.status || 'pending';
+      dialog.value = true;
+    } else {
+      dialog.value = false;
+    }
+  },
+  { immediate: true }
+);
+
+function close() {
+  dialog.value = false;
+  emit('close');
+}
+
+const submit = async () => {
+  loading.value = true;
+  try {
+    await api.post('/bills', {
+      name: name.value,
+      category: category.value,
+      paymentProvider: paymentProvider.value,
+      recurrence: recurrence.value,
+      amount: amount.value,
+      dueDate: dueDate.value,
+      status: status.value,
+      autoRenew: false
+    });
+    emit('created');
+    error.value = null;
+    close();
+  } catch (err) {
+    error.value = err.message;
+  } finally {
+    loading.value = false;
+  }
+};
+</script>


### PR DESCRIPTION
## Summary
- show `Nueva factura` button for services without auto-renew
- open a manual invoice form prefilled with service data
- create the invoice and refresh the grouped list

## Testing
- `No tests available`

------
https://chatgpt.com/codex/tasks/task_e_6844d0807360832f88cc5cb8099a40e1