### PR TITLE
Add Service entity and link Bills to their services

### DIFF
--- a/__tests__/unit/services/billService.test.js
+++ b/__tests__/unit/services/billService.test.js
@@ -11,6 +11,10 @@ jest.unstable_mockModule('../../../src/db/prismaClient.js', () => ({
       create: jest.fn(),
       delete: jest.fn(),
       groupBy: jest.fn()
+    },
+    service: {
+      findFirst: jest.fn(),
+      create: jest.fn()
     }
   }
 }));

--- a/frontend/src/components/BillTable.vue
+++ b/frontend/src/components/BillTable.vue
@@ -213,7 +213,7 @@ const totalPages = computed(() => Math.ceil(total.value / limit) || 1);
 const groupedBills = computed(() => {
   const map = new Map();
   bills.value.forEach((bill) => {
-    const key = `${bill.name}|${bill.paymentProvider}|${bill.category}`;
+    const key = bill.serviceId || `${bill.name}|${bill.paymentProvider}|${bill.category}`;
     if (!map.has(key)) map.set(key, []);
     map.get(key).push(bill);
   });
@@ -283,7 +283,8 @@ function history(bill) {
     query: {
       name: bill.name,
       provider: bill.paymentProvider || '',
-      category: bill.category
+      category: bill.category,
+      serviceId: bill.serviceId
     }
   });
 }
@@ -296,7 +297,8 @@ function newInvoice(bill) {
     recurrence: bill.recurrence || 'none',
     amount: bill.amount,
     dueDate: bill.dueDate.substring(0, 10),
-    status: 'pending'
+    status: 'pending',
+    serviceId: bill.serviceId
   };
 }
 

--- a/frontend/src/components/ManualInvoiceForm.vue
+++ b/frontend/src/components/ManualInvoiceForm.vue
@@ -66,6 +66,7 @@ const category = ref('');
 const paymentProvider = ref('');
 const recurrenceOptions = ['none', 'weekly', 'monthly', 'bimonthly', 'yearly'];
 const recurrence = ref('none');
+const serviceId = ref('');
 const amount = ref(0);
 const dueDate = ref('');
 const statusOptions = ['pending', 'paid', 'overdue'];
@@ -81,6 +82,7 @@ watch(
       category.value = b.category;
       paymentProvider.value = b.paymentProvider || '';
       recurrence.value = b.recurrence || 'none';
+      serviceId.value = b.serviceId || '';
       amount.value = b.amount || 0;
       dueDate.value = (b.dueDate || '').substring(0, 10);
       status.value = b.status || 'pending';
@@ -108,7 +110,8 @@ const submit = async () => {
       amount: amount.value,
       dueDate: dueDate.value,
       status: status.value,
-      autoRenew: false
+      autoRenew: false,
+      serviceId: serviceId.value
     });
     emit('created');
     error.value = null;

--- a/frontend/src/views/PaymentHistory.vue
+++ b/frontend/src/views/PaymentHistory.vue
@@ -74,6 +74,7 @@ import api from '../api.js';
 const props = defineProps({ name: String });
 const route = useRoute();
 const name = computed(() => route.query.name || props.name || '');
+const serviceId = computed(() => route.query.serviceId || '');
 const payments = ref([]);
 const loading = ref(false);
 const error = ref(null);

--- a/prisma/migrations/add-service-entity/migration.sql
+++ b/prisma/migrations/add-service-entity/migration.sql
@@ -1,0 +1,26 @@
+CREATE TABLE `Service` (
+  `id` VARCHAR(191) NOT NULL PRIMARY KEY,
+  `name` VARCHAR(191) NOT NULL,
+  `description` TEXT,
+  `category` VARCHAR(191) NOT NULL,
+  `paymentProvider` VARCHAR(191),
+  `recurrence` VARCHAR(191) NOT NULL DEFAULT 'none',
+  `autoRenew` BOOLEAN NOT NULL DEFAULT false,
+  `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  `updatedAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE=InnoDB;
+
+ALTER TABLE `Bill` ADD COLUMN `serviceId` VARCHAR(191);
+
+CREATE INDEX `Bill_serviceId_idx` ON `Bill`(`serviceId`);
+
+ALTER TABLE `Bill` ADD CONSTRAINT `Bill_serviceId_fkey` FOREIGN KEY (`serviceId`) REFERENCES `Service`(`id`) ON DELETE SET NULL;
+
+INSERT INTO `Service` (id, name, description, category, paymentProvider, recurrence, autoRenew, createdAt, updatedAt)
+SELECT UUID(), name, MAX(description), category, paymentProvider, MAX(recurrence), MAX(autoRenew), NOW(), NOW()
+FROM `Bill`
+GROUP BY name, paymentProvider, category;
+
+UPDATE `Bill` b
+JOIN `Service` s ON b.name = s.name AND (b.paymentProvider <=> s.paymentProvider) AND b.category = s.category
+SET b.serviceId = s.id;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,11 +16,16 @@ model Bill {
   status          String
   category        String
   paymentProvider String?
+  serviceId       String?
   autoRenew       Boolean  @default(false)
   recurrence      String   @default("none")
   paidAt          DateTime?
   createdAt       DateTime @default(now())
   updatedAt       DateTime @updatedAt
+
+  Service Service? @relation(fields: [serviceId], references: [id])
+
+  @@index([serviceId])
 }
 
 model Payment {
@@ -37,4 +42,18 @@ model Payment {
   Bill Bill @relation(fields: [billId], references: [id], onDelete: Cascade)
 
   @@index([billId])
+}
+
+model Service {
+  id              String   @id @default(uuid())
+  name            String
+  description     String?
+  category        String
+  paymentProvider String?
+  recurrence      String   @default("none")
+  autoRenew       Boolean  @default(false)
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
+
+  bills Bill[]
 }

--- a/src/db/prismaClient.js
+++ b/src/db/prismaClient.js
@@ -3,6 +3,7 @@ if (process.env.NODE_ENV === 'test') {
   prisma = {
     bill: {},
     payment: {},
+    service: {},
     $connect: async () => {},
     $disconnect: async () => {}
   };


### PR DESCRIPTION
## Summary
- add `Service` table and relation in Prisma schema
- update `billService` to assign bills to services
- allow grouping bills by `serviceId` in the frontend
- include `serviceId` when creating manual invoices or viewing history
- provide SQL migration to populate existing services

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844d236f324832fb04579a8cf71a571