### PR TITLE
Add service bills view and due date fix

### DIFF
--- a/frontend/src/components/BillForm.vue
+++ b/frontend/src/components/BillForm.vue
@@ -96,11 +96,16 @@ function close() {
 const submit = async () => {
   loading.value = true;
   try {
+    const due = new Date(dueDate.value);
+    if (isNaN(due)) throw new Error('Invalid due date');
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    if (due < today) throw new Error('Due date cannot be in the past');
     await api.post('/bills', {
       name: name.value,
       description: description.value,
       amount: amount.value,
-      dueDate: dueDate.value,
+      dueDate: due.toISOString(),
       paymentProvider: paymentProvider.value,
       category: category.value,
       autoRenew: autoRenew.value,

--- a/frontend/src/components/ServiceList.vue
+++ b/frontend/src/components/ServiceList.vue
@@ -1,0 +1,51 @@
+<template>
+  <div>
+    <v-progress-linear v-if="loading" indeterminate />
+    <v-alert v-else-if="error" type="error" dense>{{ error }}</v-alert>
+    <v-data-table
+      v-else
+      :headers="headers"
+      :items="services"
+      class="elevation-1"
+      hide-default-footer
+    >
+      <template #item.actions="{ item }">
+        <v-btn :to="`/services/${item.id}`" variant="text" color="primary">
+          Ver facturas
+        </v-btn>
+      </template>
+    </v-data-table>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue';
+import api from '../api.js';
+
+const services = ref([]);
+const loading = ref(false);
+const error = ref(null);
+const headers = [
+  { title: 'Nombre', key: 'name' },
+  { title: 'Categoría', key: 'category' },
+  { title: 'Proveedor', key: 'paymentProvider' },
+  { title: 'Recurrencia', key: 'recurrence' },
+  { title: 'Acciones', key: 'actions', sortable: false }
+];
+
+const fetchServices = async () => {
+  loading.value = true;
+  try {
+    const { data } = await api.get('/services');
+    services.value = data;
+    error.value = null;
+  } catch (err) {
+    error.value = err.message;
+  } finally {
+    loading.value = false;
+  }
+};
+
+onMounted(fetchServices);
+</script>
+

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -3,9 +3,11 @@ import Dashboard from '../views/Dashboard.vue';
 import PaymentHistory from '../views/PaymentHistory.vue';
 import Analytics from '../views/Analytics.vue';
 import Assistant from '../views/Assistant.vue';
+import ServiceBills from '../views/ServiceBills.vue';
 
 const routes = [
   { path: '/', component: Dashboard },
+  { path: '/services/:id', component: ServiceBills },
   { path: '/history/:name?', component: PaymentHistory, props: true },
   { path: '/analytics', component: Analytics },
   { path: '/assistant', component: Assistant }

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -2,12 +2,12 @@
   <div>
     <SummaryWidget />
     <BillForm @added="refresh" @notify="notify" />
-    <BillTable :key="refreshKey" @notify="notify" />
+    <ServiceList :key="refreshKey" />
   </div>
 </template>
 
 <script setup>
-import BillTable from '../components/BillTable.vue';
+import ServiceList from '../components/ServiceList.vue';
 import BillForm from '../components/BillForm.vue';
 import SummaryWidget from '../components/SummaryWidget.vue';
 import { ref } from 'vue';

--- a/frontend/src/views/ServiceBills.vue
+++ b/frontend/src/views/ServiceBills.vue
@@ -1,0 +1,96 @@
+<template>
+  <v-container>
+    <h2>{{ service?.name }} - Facturas</h2>
+    <v-btn variant="text" to="/">Back</v-btn>
+    <div class="my-2 d-flex gap-2">
+      <v-chip color="green">💰 Paid: {{ totals.paid.toFixed(2) }}</v-chip>
+      <v-chip color="orange">⏳ Pending: {{ totals.pending.toFixed(2) }}</v-chip>
+      <v-chip color="red">⚠️ Overdue: {{ totals.overdue.toFixed(2) }}</v-chip>
+    </div>
+    <v-select
+      v-model="filter"
+      :items="statusOptions"
+      label="Status"
+      density="compact"
+      clearable
+      class="mb-2"
+    />
+    <v-progress-linear v-if="loading" indeterminate />
+    <v-alert v-else-if="error" type="error" dense>{{ error }}</v-alert>
+    <v-data-table
+      v-else
+      :headers="headers"
+      :items="filteredBills"
+      class="elevation-1"
+      hide-default-footer
+    >
+      <template #item.dueDate="{ item }">{{ format(item.dueDate) }}</template>
+      <template #item.amount="{ item }">{{ item.amount.toFixed(2) }}</template>
+    </v-data-table>
+  </v-container>
+</template>
+
+<script setup>
+import { ref, onMounted, computed } from 'vue';
+import { useRoute } from 'vue-router';
+import api from '../api.js';
+
+const route = useRoute();
+const id = route.params.id;
+
+const service = ref(null);
+const bills = ref([]);
+const loading = ref(false);
+const error = ref(null);
+const filter = ref('');
+
+const statusOptions = [
+  { title: 'All', value: '' },
+  { title: 'paid', value: 'paid' },
+  { title: 'pending', value: 'pending' },
+  { title: 'overdue', value: 'overdue' }
+];
+
+const headers = [
+  { title: 'Nombre', key: 'name' },
+  { title: 'Descripción', key: 'description' },
+  { title: 'Due Date', key: 'dueDate' },
+  { title: 'Monto', key: 'amount' },
+  { title: 'Estado', key: 'status' }
+];
+
+const fetchData = async () => {
+  loading.value = true;
+  try {
+    const { data } = await api.get(`/services/${id}`);
+    service.value = data;
+    bills.value = data.bills || [];
+    error.value = null;
+  } catch (err) {
+    error.value = err.message;
+  } finally {
+    loading.value = false;
+  }
+};
+
+onMounted(fetchData);
+
+const filteredBills = computed(() =>
+  filter.value ? bills.value.filter((b) => b.status === filter.value) : bills.value
+);
+
+const totals = computed(() => {
+  return bills.value.reduce(
+    (acc, b) => {
+      acc[b.status] += b.amount;
+      return acc;
+    },
+    { paid: 0, pending: 0, overdue: 0 }
+  );
+});
+
+function format(d) {
+  return new Date(d).toLocaleDateString();
+}
+</script>
+

--- a/src/controllers/serviceController.js
+++ b/src/controllers/serviceController.js
@@ -1,0 +1,19 @@
+import { listServices, getServiceById } from '../services/serviceService.js';
+
+export const getAll = async (req, res, next) => {
+  try {
+    res.json(await listServices());
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const getById = async (req, res, next) => {
+  try {
+    const service = await getServiceById(req.params.id);
+    if (!service) return res.status(404).json({ message: 'Service not found' });
+    res.json(service);
+  } catch (err) {
+    next(err);
+  }
+};

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import cors from 'cors';
 import dotenv from 'dotenv';
 import billRoutes from './routes/billRoutes.js';
 import paymentRoutes from './routes/paymentRoutes.js';
+import serviceRoutes from './routes/serviceRoutes.js';
 import assistantRoutes from './routes/assistantRoutes.js';
 import chatRoutes from './routes/chatRoutes.js';
 import logger from './middleware/logger.js';
@@ -24,6 +25,7 @@ app.use(logger);
 
 app.use('/bills', billRoutes);
 app.use('/payments', paymentRoutes);
+app.use('/services', serviceRoutes);
 app.use('/assistant', assistantRoutes);
 app.use('/chat', chatRoutes);
 

--- a/src/routes/serviceRoutes.js
+++ b/src/routes/serviceRoutes.js
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import * as controller from '../controllers/serviceController.js';
+
+const router = Router();
+
+router.get('/', controller.getAll);
+router.get('/:id', controller.getById);
+
+export default router;

--- a/src/services/serviceService.js
+++ b/src/services/serviceService.js
@@ -1,0 +1,10 @@
+import prisma from '../db/prismaClient.js';
+
+export const listServices = async () =>
+  prisma.service.findMany({ orderBy: { name: 'asc' } });
+
+export const getServiceById = async (id) =>
+  prisma.service.findUnique({
+    where: { id },
+    include: { bills: true }
+  });

--- a/tests/integration/services.test.js
+++ b/tests/integration/services.test.js
@@ -1,0 +1,42 @@
+import request from 'supertest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+process.env.NODE_ENV = 'test';
+vi.mock('../../src/db/prismaClient.js', () => ({
+  default: {
+    $connect: vi.fn().mockResolvedValue(),
+    $disconnect: vi.fn().mockResolvedValue(),
+    service: {}
+  }
+}));
+vi.mock('openai', () => ({ default: vi.fn() }));
+import app from '../../src/index.js';
+import * as serviceService from '../../src/services/serviceService.js';
+
+vi.mock('../../src/services/serviceService.js');
+
+const sampleService = {
+  id: '1',
+  name: 'Internet',
+  category: 'utilities',
+  paymentProvider: 'Visa',
+  recurrence: 'monthly',
+  bills: []
+};
+
+describe('Service endpoints', () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  it('GET /services should list services', async () => {
+    serviceService.listServices.mockResolvedValue([sampleService]);
+    const res = await request(app).get('/services');
+    expect(res.status).toBe(200);
+    expect(res.body[0].name).toBe('Internet');
+  });
+
+  it('GET /services/:id should return service by id', async () => {
+    serviceService.getServiceById.mockResolvedValue(sampleService);
+    const res = await request(app).get('/services/1');
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBe('1');
+  });
+});


### PR DESCRIPTION
## Summary
- add API routes and controller for services
- show services instead of bills on dashboard
- add ServiceBills view to filter bills and show totals per status
- ensure dueDate is validated and formatted in BillForm
- tests for new service endpoints

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844d7222eb4832fb9ba1de770f48ae8