### PR TITLE
🎛️ Restore filters and actions in grouped Service view

### DIFF
--- a/frontend/src/components/ServiceList.vue
+++ b/frontend/src/components/ServiceList.vue
@@ -1,5 +1,34 @@
 <template>
   <div>
+    <v-row class="mb-2" align="center">
+      <v-col cols="12" sm="4">
+        <v-select
+          v-model="category"
+          :items="categoryOptions"
+          label="Categor\u00eda"
+          density="compact"
+          clearable
+        />
+      </v-col>
+      <v-col cols="12" sm="4">
+        <v-select
+          v-model="paymentProvider"
+          :items="providers"
+          label="Proveedor"
+          density="compact"
+          clearable
+        />
+      </v-col>
+      <v-col cols="12" sm="4">
+        <v-select
+          v-model="recurrence"
+          :items="recurrenceOptions"
+          label="Recurrencia"
+          density="compact"
+          clearable
+        />
+      </v-col>
+    </v-row>
     <v-progress-linear v-if="loading" indeterminate />
     <v-alert v-else-if="error" type="error" dense>{{ error }}</v-alert>
     <v-data-table
@@ -13,18 +42,49 @@
         <v-btn :to="`/services/${item.id}`" variant="text" color="primary">
           Ver facturas
         </v-btn>
+        <v-btn icon @click="newInvoice(item)">
+          <v-icon>mdi-plus</v-icon>
+        </v-btn>
       </template>
     </v-data-table>
+    <ManualInvoiceForm
+      v-if="newBill"
+      :bill="newBill"
+      @created="onCreated"
+      @close="closeNew"
+    />
   </div>
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue';
+import { ref, onMounted, watch } from 'vue';
 import api from '../api.js';
+import ManualInvoiceForm from './ManualInvoiceForm.vue';
 
 const services = ref([]);
 const loading = ref(false);
 const error = ref(null);
+const category = ref('');
+const paymentProvider = ref('');
+const recurrence = ref('');
+const newBill = ref(null);
+
+const providers = ['Visa', 'Mastercard', 'MercadoPago', 'Google Play', 'MODO', 'PayPal'];
+const categoryOptions = [
+  { title: 'All', value: '' },
+  { title: 'utilities', value: 'utilities' },
+  { title: 'subscriptions', value: 'subscriptions' },
+  { title: 'taxes', value: 'taxes' },
+  { title: 'others', value: 'others' }
+];
+const recurrenceOptions = [
+  { title: 'All', value: '' },
+  { title: 'weekly', value: 'weekly' },
+  { title: 'monthly', value: 'monthly' },
+  { title: 'bimonthly', value: 'bimonthly' },
+  { title: 'yearly', value: 'yearly' },
+  { title: 'none', value: 'none' }
+];
 const headers = [
   { title: 'Nombre', key: 'name' },
   { title: 'Categoría', key: 'category' },
@@ -36,7 +96,13 @@ const headers = [
 const fetchServices = async () => {
   loading.value = true;
   try {
-    const { data } = await api.get('/services');
+    const { data } = await api.get('/services', {
+      params: {
+        category: category.value,
+        paymentProvider: paymentProvider.value,
+        recurrence: recurrence.value
+      }
+    });
     services.value = data;
     error.value = null;
   } catch (err) {
@@ -47,5 +113,27 @@ const fetchServices = async () => {
 };
 
 onMounted(fetchServices);
+watch([category, paymentProvider, recurrence], fetchServices);
+
+function newInvoice(service) {
+  newBill.value = {
+    name: service.name,
+    category: service.category,
+    paymentProvider: service.paymentProvider || '',
+    recurrence: service.recurrence || 'none',
+    amount: 0,
+    dueDate: '',
+    status: 'pending',
+    serviceId: service.id
+  };
+}
+
+function closeNew() {
+  newBill.value = null;
+}
+
+function onCreated() {
+  closeNew();
+}
 </script>
 

--- a/src/controllers/serviceController.js
+++ b/src/controllers/serviceController.js
@@ -2,7 +2,7 @@ import { listServices, getServiceById } from '../services/serviceService.js';
 
 export const getAll = async (req, res, next) => {
   try {
-    res.json(await listServices());
+    res.json(await listServices(req.query));
   } catch (err) {
     next(err);
   }

--- a/src/services/serviceService.js
+++ b/src/services/serviceService.js
@@ -1,7 +1,13 @@
 import prisma from '../db/prismaClient.js';
 
-export const listServices = async () =>
-  prisma.service.findMany({ orderBy: { name: 'asc' } });
+export const listServices = async (query = {}) => {
+  const { category, recurrence, paymentProvider } = query;
+  const where = {};
+  if (category) where.category = category;
+  if (recurrence) where.recurrence = recurrence;
+  if (paymentProvider) where.paymentProvider = paymentProvider;
+  return prisma.service.findMany({ where, orderBy: { name: 'asc' } });
+};
 
 export const getServiceById = async (id) =>
   prisma.service.findUnique({

--- a/tests/integration/services.test.js
+++ b/tests/integration/services.test.js
@@ -33,6 +33,17 @@ describe('Service endpoints', () => {
     expect(res.body[0].name).toBe('Internet');
   });
 
+  it('GET /services with filters should pass query to service', async () => {
+    serviceService.listServices.mockResolvedValue([]);
+    await request(app)
+      .get('/services')
+      .query({ category: 'utilities', paymentProvider: 'Visa' });
+    expect(serviceService.listServices).toHaveBeenCalledWith({
+      category: 'utilities',
+      paymentProvider: 'Visa'
+    });
+  });
+
   it('GET /services/:id should return service by id', async () => {
     serviceService.getServiceById.mockResolvedValue(sampleService);
     const res = await request(app).get('/services/1');


### PR DESCRIPTION
## Summary
- implement filters in `ServiceList.vue` and add new invoice action
- pass query parameters to service controller
- allow filtering in serviceService
- test service filters

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844da3558c0832f8658ce5340313780