### PR TITLE
Add actions to service invoice view

### DIFF
--- a/frontend/src/views/ServiceBills.vue
+++ b/frontend/src/views/ServiceBills.vue
@@ -2,6 +2,14 @@
   <v-container>
     <h2>{{ service?.name }} - Facturas</h2>
     <v-btn variant="text" to="/">Back</v-btn>
+    <v-btn
+      v-if="service?.autoRenew"
+      class="ml-2"
+      color="red"
+      @click="cancelSub"
+    >
+      ❌ Cancelar suscripción
+    </v-btn>
     <div class="my-2 d-flex gap-2">
       <v-chip color="green">💰 Paid: {{ totals.paid.toFixed(2) }}</v-chip>
       <v-chip color="orange">⏳ Pending: {{ totals.pending.toFixed(2) }}</v-chip>
@@ -26,7 +34,28 @@
     >
       <template #item.dueDate="{ item }">{{ format(item.dueDate) }}</template>
       <template #item.amount="{ item }">{{ item.amount.toFixed(2) }}</template>
+      <template #item.actions="{ item }">
+        <v-btn
+          v-if="item.status === 'pending'"
+          size="small"
+          color="green"
+          variant="text"
+          @click="pay(item)"
+        >
+          Pagar
+        </v-btn>
+        <v-btn size="small" variant="text" @click="edit(item)">✏️ Editar</v-btn>
+        <v-btn size="small" variant="text" color="red" @click="remove(item)">
+          🗑️
+        </v-btn>
+      </template>
     </v-data-table>
+    <EditBillForm
+      v-if="editingBill"
+      :bill="editingBill"
+      @updated="onUpdated"
+      @close="closeEdit"
+    />
   </v-container>
 </template>
 
@@ -34,6 +63,7 @@
 import { ref, onMounted, computed } from 'vue';
 import { useRoute } from 'vue-router';
 import api from '../api.js';
+import EditBillForm from '../components/EditBillForm.vue';
 
 const route = useRoute();
 const id = route.params.id;
@@ -43,6 +73,7 @@ const bills = ref([]);
 const loading = ref(false);
 const error = ref(null);
 const filter = ref('');
+const editingBill = ref(null);
 
 const statusOptions = [
   { title: 'All', value: '' },
@@ -56,7 +87,8 @@ const headers = [
   { title: 'Descripción', key: 'description' },
   { title: 'Due Date', key: 'dueDate' },
   { title: 'Monto', key: 'amount' },
-  { title: 'Estado', key: 'status' }
+  { title: 'Estado', key: 'status' },
+  { title: 'Acciones', key: 'actions', sortable: false }
 ];
 
 const fetchData = async () => {
@@ -91,6 +123,45 @@ const totals = computed(() => {
 
 function format(d) {
   return new Date(d).toLocaleDateString();
+}
+
+function edit(bill) {
+  editingBill.value = { ...bill };
+}
+
+function closeEdit() {
+  editingBill.value = null;
+}
+
+async function onUpdated() {
+  await fetchData();
+}
+
+async function pay(bill) {
+  try {
+    await api.put(`/bills/${bill.id}`, { status: 'paid' });
+    await fetchData();
+  } catch (err) {
+    error.value = err.message;
+  }
+}
+
+async function remove(bill) {
+  try {
+    await api.delete(`/bills/${bill.id}`);
+    await fetchData();
+  } catch (err) {
+    error.value = err.message;
+  }
+}
+
+async function cancelSub() {
+  try {
+    await api.put(`/services/${id}`, { autoRenew: false });
+    service.value.autoRenew = false;
+  } catch (err) {
+    error.value = err.message;
+  }
 }
 </script>
 

--- a/src/controllers/serviceController.js
+++ b/src/controllers/serviceController.js
@@ -1,4 +1,8 @@
-import { listServices, getServiceById } from '../services/serviceService.js';
+import {
+  listServices,
+  getServiceById,
+  updateService
+} from '../services/serviceService.js';
 
 export const getAll = async (req, res, next) => {
   try {
@@ -11,6 +15,16 @@ export const getAll = async (req, res, next) => {
 export const getById = async (req, res, next) => {
   try {
     const service = await getServiceById(req.params.id);
+    if (!service) return res.status(404).json({ message: 'Service not found' });
+    res.json(service);
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const update = async (req, res, next) => {
+  try {
+    const service = await updateService(req.params.id, req.body);
     if (!service) return res.status(404).json({ message: 'Service not found' });
     res.json(service);
   } catch (err) {

--- a/src/routes/serviceRoutes.js
+++ b/src/routes/serviceRoutes.js
@@ -5,5 +5,6 @@ const router = Router();
 
 router.get('/', controller.getAll);
 router.get('/:id', controller.getById);
+router.put('/:id', controller.update);
 
 export default router;

--- a/src/services/serviceService.js
+++ b/src/services/serviceService.js
@@ -14,3 +14,9 @@ export const getServiceById = async (id) =>
     where: { id },
     include: { bills: true }
   });
+
+export const updateService = async (id, data) => {
+  const existing = await prisma.service.findUnique({ where: { id } });
+  if (!existing) return null;
+  return prisma.service.update({ where: { id }, data });
+};

--- a/tests/integration/services.test.js
+++ b/tests/integration/services.test.js
@@ -20,6 +20,7 @@ const sampleService = {
   category: 'utilities',
   paymentProvider: 'Visa',
   recurrence: 'monthly',
+  autoRenew: true,
   bills: []
 };
 
@@ -49,5 +50,15 @@ describe('Service endpoints', () => {
     const res = await request(app).get('/services/1');
     expect(res.status).toBe(200);
     expect(res.body.id).toBe('1');
+  });
+
+  it('PUT /services/:id should update service', async () => {
+    serviceService.updateService.mockResolvedValue({
+      ...sampleService,
+      autoRenew: false
+    });
+    const res = await request(app).put('/services/1').send({ autoRenew: false });
+    expect(res.status).toBe(200);
+    expect(res.body.autoRenew).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- implement service update endpoint to toggle `autoRenew`
- expose new route to update services
- update service tests
- enhance ServiceBills view with Pay/Edit/Delete actions
- allow canceling subscription from service page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844dd9a422c832f9015483de99ccf36