### PR TITLE
📊 Improve service view with last invoice details

### DIFF
--- a/src/services/serviceService.js
+++ b/src/services/serviceService.js
@@ -6,7 +6,12 @@ export const listServices = async (query = {}) => {
   if (category) where.category = category;
   if (recurrence) where.recurrence = recurrence;
   if (paymentProvider) where.paymentProvider = paymentProvider;
-  return prisma.service.findMany({ where, orderBy: { name: 'asc' } });
+  const services = await prisma.service.findMany({
+    where,
+    orderBy: { name: 'asc' },
+    include: { bills: { orderBy: { dueDate: 'desc' }, take: 1 } }
+  });
+  return services.map((s) => ({ ...s, lastBill: s.bills[0] || null, bills: undefined }));
 };
 
 export const getServiceById = async (id) =>


### PR DESCRIPTION
## Summary
- show latest invoice info for each service by returning `lastBill` in `listServices`
- display last bill amount, month and status with colored icons in ServiceList
- improve action buttons with icons and tooltips
- persist filters in localStorage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844e2c9ba48832fb1af31ff6bd9b616