### PR TITLE
🎯 Final UX polish: quick actions, overdue info, tooltips, archive service

### DIFF
--- a/frontend/src/components/QuickBillDialog.vue
+++ b/frontend/src/components/QuickBillDialog.vue
@@ -1,0 +1,77 @@
+<template>
+  <v-dialog v-model="open" max-width="500">
+    <v-card v-if="bill">
+      <v-card-title class="pb-0">Detalle factura</v-card-title>
+      <v-card-text class="pt-0">
+        <div class="mb-2">Monto: {{ formatAmount(bill.amount) }}</div>
+        <div class="mb-2">Vencimiento: {{ formatDate(bill.dueDate) }}</div>
+        <div>Estado: {{ bill.status }}</div>
+      </v-card-text>
+      <v-card-actions>
+        <v-btn variant="text" color="green" @click="markPaid" :disabled="bill.status==='paid'">Marcar como pagado</v-btn>
+        <v-btn variant="text" @click="edit">Editar</v-btn>
+        <v-btn variant="text" color="red" @click="remove">Eliminar</v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+  <EditBillForm v-if="editing" :bill="bill" @updated="onUpdated" @close="closeEdit" />
+</template>
+
+<script setup>
+import { ref, watch } from 'vue';
+import EditBillForm from './EditBillForm.vue';
+import api from '../api.js';
+
+const props = defineProps({ bill: Object });
+const emit = defineEmits(['updated', 'close']);
+
+const open = ref(false);
+const editing = ref(false);
+
+watch(
+  () => props.bill,
+  (b) => {
+    open.value = !!b;
+  },
+  { immediate: true }
+);
+
+function close() {
+  open.value = false;
+  emit('close');
+}
+
+async function markPaid() {
+  await api.put(`/bills/${props.bill.id}`, { status: 'paid' });
+  emit('updated');
+  close();
+}
+
+function edit() {
+  editing.value = true;
+}
+
+function closeEdit() {
+  editing.value = false;
+  close();
+}
+
+function onUpdated() {
+  editing.value = false;
+  emit('updated');
+  close();
+}
+
+async function remove() {
+  await api.delete(`/bills/${props.bill.id}`);
+  emit('updated');
+  close();
+}
+
+function formatDate(d) {
+  return new Date(d).toLocaleDateString();
+}
+function formatAmount(a) {
+  return `$${Number(a).toFixed(2)}`;
+}
+</script>

--- a/frontend/src/components/ServiceList.vue
+++ b/frontend/src/components/ServiceList.vue
@@ -2,33 +2,54 @@
   <div>
     <v-row class="mb-2" align="center">
       <v-col cols="12" sm="4">
-        <v-select
-          v-model="category"
-          :items="categoryOptions"
-          label="Categor\u00eda"
-          density="compact"
-          clearable
-        />
+        <v-tooltip text="Filtrar por categor\u00eda">
+          <template #activator="{ props }">
+            <v-select
+              v-bind="props"
+              v-model="category"
+              :items="categoryOptions"
+              label="Categor\u00eda"
+              density="compact"
+              clearable
+            />
+          </template>
+        </v-tooltip>
       </v-col>
       <v-col cols="12" sm="4">
-        <v-select
-          v-model="paymentProvider"
-          :items="providers"
-          label="Proveedor"
-          density="compact"
-          clearable
-        />
+        <v-tooltip text="Filtrar por proveedor">
+          <template #activator="{ props }">
+            <v-select
+              v-bind="props"
+              v-model="paymentProvider"
+              :items="providers"
+              label="Proveedor"
+              density="compact"
+              clearable
+            />
+          </template>
+        </v-tooltip>
       </v-col>
       <v-col cols="12" sm="4">
-        <v-select
-          v-model="recurrence"
-          :items="recurrenceOptions"
-          label="Recurrencia"
-          density="compact"
-          clearable
-        />
+        <v-tooltip text="Filtrar por recurrencia">
+          <template #activator="{ props }">
+            <v-select
+              v-bind="props"
+              v-model="recurrence"
+              :items="recurrenceOptions"
+              label="Recurrencia"
+              density="compact"
+              clearable
+            />
+          </template>
+        </v-tooltip>
       </v-col>
     </v-row>
+    <v-switch
+      v-model="dueSoon"
+      density="compact"
+      label="Vencimientos en 7 d\u00edas"
+      class="mb-2"
+    />
     <v-progress-linear v-if="loading" indeterminate />
     <v-alert v-else-if="error" type="error" dense>{{ error }}</v-alert>
     <v-data-table
@@ -38,15 +59,48 @@
       class="elevation-1"
       hide-default-footer
     >
+      <template #item.name="{ item }">
+        {{ item.name }}
+        <v-tooltip v-if="item.autoRenew" text="Renovaci\u00f3n autom\u00e1tica activada">
+          <template #activator="{ props }">
+            <v-icon v-bind="props" class="ml-1" size="small">mdi-autorenew</v-icon>
+          </template>
+        </v-tooltip>
+      </template>
       <template #item.lastBill="{ item }">
-        <span v-if="item.lastBill">
-          {{ formatAmount(item.lastBill.amount) }} ({{ shortMonth(item.lastBill.dueDate) }})
-          <v-icon
-            :color="statusColor(item.lastBill.status)"
-            class="ml-1"
-            :icon="statusIcon(item.lastBill.status)"
-            size="small"
-          />
+        <span v-if="item.lastBill" class="d-inline-flex align-center">
+          <v-tooltip text="Monto de la \u00faltima factura">
+            <template #activator="{ props }">
+              <span class="pointer" v-bind="props" @click="openQuick(item.lastBill)">
+                {{ formatAmount(item.lastBill.amount) }}
+              </span>
+            </template>
+          </v-tooltip>
+          <v-tooltip :text="`Venci\u00f3 el ${formatDate(item.lastBill.dueDate)}`">
+            <template #activator="{ props }">
+              <span class="pointer ml-1" v-bind="props" @click="openQuick(item.lastBill)">
+                ({{ shortMonth(item.lastBill.dueDate) }})
+              </span>
+            </template>
+          </v-tooltip>
+          <v-tooltip :text="statusLabel(item.lastBill)">
+            <template #activator="{ props }">
+              <v-icon
+                v-bind="props"
+                :color="statusColor(item.lastBill.status)"
+                class="ml-1 pointer"
+                :icon="statusIcon(item.lastBill.status)"
+                size="small"
+                @click="openQuick(item.lastBill)"
+              />
+            </template>
+          </v-tooltip>
+          <v-icon icon="mdi-chevron-right" size="small" class="ml-1 pointer" @click="openQuick(item.lastBill)" />
+          <v-tooltip v-if="item.lastBill.status === 'overdue'" :text="`Venci\u00f3 el ${formatDate(item.lastBill.dueDate)}`">
+            <template #activator="{ props }">
+              <v-badge v-bind="props" color="red" class="ml-1">⚠ overdue ({{ overdueDays(item.lastBill.dueDate) }} d\u00edas)</v-badge>
+            </template>
+          </v-tooltip>
         </span>
         <span v-else>-</span>
       </template>
@@ -70,6 +124,13 @@
             </v-btn>
           </template>
         </v-tooltip>
+        <v-tooltip text="Archivar servicio">
+          <template #activator="{ props }">
+            <v-btn v-bind="props" icon @click="archive(item)">
+              <v-icon>mdi-archive</v-icon>
+            </v-btn>
+          </template>
+        </v-tooltip>
       </template>
     </v-data-table>
     <ManualInvoiceForm
@@ -78,6 +139,12 @@
       @created="onCreated"
       @close="closeNew"
     />
+    <QuickBillDialog
+      v-if="selectedBill"
+      :bill="selectedBill"
+      @updated="fetchServices"
+      @close="closeQuick"
+    />
   </div>
 </template>
 
@@ -85,6 +152,7 @@
 import { ref, onMounted, watch } from 'vue';
 import api from '../api.js';
 import ManualInvoiceForm from './ManualInvoiceForm.vue';
+import QuickBillDialog from './QuickBillDialog.vue';
 
 const services = ref([]);
 const loading = ref(false);
@@ -93,6 +161,8 @@ const category = ref(localStorage.getItem('svc_category') || '');
 const paymentProvider = ref(localStorage.getItem('svc_provider') || '');
 const recurrence = ref(localStorage.getItem('svc_recurrence') || '');
 const newBill = ref(null);
+const selectedBill = ref(null);
+const dueSoon = ref(localStorage.getItem('svc_dueSoon') === '1');
 
 const providers = ['Visa', 'Mastercard', 'MercadoPago', 'Google Play', 'MODO', 'PayPal'];
 const categoryOptions = [
@@ -126,7 +196,8 @@ const fetchServices = async () => {
       params: {
         category: category.value,
         paymentProvider: paymentProvider.value,
-        recurrence: recurrence.value
+        recurrence: recurrence.value,
+        dueSoon: dueSoon.value ? 7 : undefined
       }
     });
     services.value = data;
@@ -139,10 +210,11 @@ const fetchServices = async () => {
 };
 
 onMounted(fetchServices);
-watch([category, paymentProvider, recurrence], () => {
+watch([category, paymentProvider, recurrence, dueSoon], () => {
   localStorage.setItem('svc_category', category.value);
   localStorage.setItem('svc_provider', paymentProvider.value);
   localStorage.setItem('svc_recurrence', recurrence.value);
+  localStorage.setItem('svc_dueSoon', dueSoon.value ? '1' : '0');
   fetchServices();
 });
 
@@ -165,6 +237,36 @@ function closeNew() {
 
 function onCreated() {
   closeNew();
+}
+
+function openQuick(bill) {
+  selectedBill.value = bill;
+}
+
+function closeQuick() {
+  selectedBill.value = null;
+}
+
+async function archive(service) {
+  try {
+    await api.put(`/services/${service.id}`, { archived: true });
+    fetchServices();
+  } catch (err) {
+    error.value = err.message;
+  }
+}
+
+function overdueDays(date) {
+  const diff = Math.floor((new Date() - new Date(date)) / 86400000);
+  return diff > 0 ? diff : 0;
+}
+
+function formatDate(d) {
+  return new Date(d).toLocaleDateString();
+}
+
+function statusLabel(bill) {
+  return { paid: 'Pagado', pending: 'Pendiente', overdue: 'Vencido' }[bill.status];
 }
 
 function formatAmount(val) {

--- a/prisma/migrations/add-service-archived/migration.sql
+++ b/prisma/migrations/add-service-archived/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `Service` ADD COLUMN `archived` BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -52,6 +52,7 @@ model Service {
   paymentProvider String?
   recurrence      String   @default("none")
   autoRenew       Boolean  @default(false)
+  archived        Boolean  @default(false)
   createdAt       DateTime @default(now())
   updatedAt       DateTime @updatedAt
 

--- a/src/services/serviceService.js
+++ b/src/services/serviceService.js
@@ -1,11 +1,21 @@
 import prisma from '../db/prismaClient.js';
 
 export const listServices = async (query = {}) => {
-  const { category, recurrence, paymentProvider } = query;
-  const where = {};
+  const { category, recurrence, paymentProvider, dueSoon } = query;
+  const where = { archived: false };
   if (category) where.category = category;
   if (recurrence) where.recurrence = recurrence;
   if (paymentProvider) where.paymentProvider = paymentProvider;
+  if (dueSoon) {
+    const soon = new Date();
+    soon.setDate(soon.getDate() + Number(dueSoon));
+    where.bills = {
+      some: {
+        status: { not: 'paid' },
+        dueDate: { lte: soon }
+      }
+    };
+  }
   const services = await prisma.service.findMany({
     where,
     orderBy: { name: 'asc' },


### PR DESCRIPTION
## Summary
- add `archived` field to Service model and migration
- filter archived services and allow dueSoon filter
- add QuickBillDialog component for quick bill actions
- enhance ServiceList with tooltips, overdue info, auto-renew icon, archive button, and dueSoon switch

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844e568e478832fa0aaece3e8ed2d96