### PR TITLE
🤖 Add Monthly Summary logic to backend and frontend

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -25,6 +25,12 @@
           :active="route.path.startsWith('/analytics')"
         />
         <v-list-item
+          to="/summary"
+          prepend-icon="mdi-table"
+          title="Resumen"
+          :active="route.path.startsWith('/summary')"
+        />
+        <v-list-item
           to="/assistant"
           prepend-icon="mdi-robot"
           title="Assistant"

--- a/frontend/src/components/QuickBillDialog.vue
+++ b/frontend/src/components/QuickBillDialog.vue
@@ -6,6 +6,14 @@
         <div class="mb-2">Monto: {{ formatAmount(bill.amount) }}</div>
         <div class="mb-2">Vencimiento: {{ formatDate(bill.dueDate) }}</div>
         <div>Estado: {{ bill.status }}</div>
+        <v-select
+          v-if="bill.status !== 'paid'"
+          v-model="provider"
+          :items="providers"
+          label="Medio de pago"
+          density="compact"
+          class="mt-2"
+        />
       </v-card-text>
       <v-card-actions>
         <v-btn variant="text" color="green" @click="markPaid" :disabled="bill.status==='paid'">Marcar como pagado</v-btn>
@@ -27,11 +35,14 @@ const emit = defineEmits(['updated', 'close']);
 
 const open = ref(false);
 const editing = ref(false);
+const providers = ['Visa', 'Mastercard', 'MercadoPago', 'Google Play', 'MODO', 'PayPal'];
+const provider = ref(providers[0]);
 
 watch(
   () => props.bill,
   (b) => {
     open.value = !!b;
+    if (b) provider.value = b.paymentProvider || providers[0];
   },
   { immediate: true }
 );
@@ -42,7 +53,7 @@ function close() {
 }
 
 async function markPaid() {
-  await api.put(`/bills/${props.bill.id}`, { status: 'paid' });
+  await api.put(`/bills/${props.bill.id}`, { status: 'paid', paymentProvider: provider.value });
   emit('updated');
   close();
 }

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -4,13 +4,15 @@ import PaymentHistory from '../views/PaymentHistory.vue';
 import Analytics from '../views/Analytics.vue';
 import Assistant from '../views/Assistant.vue';
 import ServiceBills from '../views/ServiceBills.vue';
+import Summary from '../views/Summary.vue';
 
 const routes = [
   { path: '/', component: Dashboard },
   { path: '/services/:id', component: ServiceBills },
   { path: '/history/:name?', component: PaymentHistory, props: true },
   { path: '/analytics', component: Analytics },
-  { path: '/assistant', component: Assistant }
+  { path: '/assistant', component: Assistant },
+  { path: '/summary', component: Summary }
 ];
 
 export default createRouter({

--- a/frontend/src/views/ServiceBills.vue
+++ b/frontend/src/views/ServiceBills.vue
@@ -139,7 +139,8 @@ async function onUpdated() {
 
 async function pay(bill) {
   try {
-    await api.put(`/bills/${bill.id}`, { status: 'paid' });
+    const provider = prompt('Payment provider', bill.paymentProvider || '');
+    await api.put(`/bills/${bill.id}`, { status: 'paid', paymentProvider: provider });
     await fetchData();
   } catch (err) {
     error.value = err.message;

--- a/frontend/src/views/Summary.vue
+++ b/frontend/src/views/Summary.vue
@@ -1,0 +1,55 @@
+<template>
+  <v-container>
+    <h2>Resumen Mensual</h2>
+    <v-select class="mb-4" v-model="year" :items="years" label="Año" density="compact" />
+    <v-data-table :headers="headers" :items="summary" class="elevation-1 mb-4" hide-default-footer />
+    <v-card class="pa-4">
+      <canvas id="stacked" />
+    </v-card>
+  </v-container>
+</template>
+
+<script setup>
+import { ref, watch, onMounted } from 'vue';
+import api from '../api.js';
+import Chart from 'chart.js/auto';
+
+const year = ref(new Date().getFullYear());
+const years = Array.from({ length: 5 }, (_, i) => year.value - i);
+const summary = ref([]);
+let chart;
+
+const headers = [
+  { title: 'Mes', key: 'month' },
+  { title: 'Estado', key: 'status' },
+  { title: 'Total', key: 'total' },
+  { title: 'Cantidad', key: 'count' }
+];
+
+async function fetchSummary() {
+  const { data } = await api.get('/summary/monthly', { params: { year: year.value } });
+  summary.value = data;
+  buildChart();
+}
+
+function buildChart() {
+  const months = [...new Set(summary.value.map(s => s.month))].sort();
+  const statuses = [...new Set(summary.value.map(s => s.status))];
+  const datasets = statuses.map(status => ({
+    label: status,
+    data: months.map(m => {
+      const found = summary.value.find(s => s.month === m && s.status === status);
+      return found ? found.total : 0;
+    })
+  }));
+  if (chart) chart.destroy();
+  chart = new Chart(document.getElementById('stacked'), {
+    type: 'bar',
+    data: { labels: months, datasets },
+    options: { scales: { x: { stacked: true }, y: { stacked: true } } }
+  });
+}
+
+onMounted(fetchSummary);
+watch(year, fetchSummary);
+</script>

--- a/prisma/migrations/remove-bill-fields/migration.sql
+++ b/prisma/migrations/remove-bill-fields/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `Bill` DROP COLUMN `name`, DROP COLUMN `description`;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -9,8 +9,6 @@ datasource db {
 
 model Bill {
   id              String   @id @default(uuid())
-  name            String
-  description     String?
   amount          Float
   dueDate         DateTime
   status          String

--- a/src/controllers/summaryController.js
+++ b/src/controllers/summaryController.js
@@ -1,0 +1,11 @@
+import { getMonthlyStatusByMonth } from '../services/billService.js';
+
+export const monthly = async (req, res, next) => {
+  try {
+    const year = req.query.year ? Number(req.query.year) : undefined;
+    const summary = await getMonthlyStatusByMonth(year);
+    res.json(summary);
+  } catch (err) {
+    next(err);
+  }
+};

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import paymentRoutes from './routes/paymentRoutes.js';
 import serviceRoutes from './routes/serviceRoutes.js';
 import assistantRoutes from './routes/assistantRoutes.js';
 import chatRoutes from './routes/chatRoutes.js';
+import summaryRoutes from './routes/summaryRoutes.js';
 import logger from './middleware/logger.js';
 import errorHandler from './middleware/errorHandler.js';
 import './reminder.js';
@@ -28,6 +29,7 @@ app.use('/payments', paymentRoutes);
 app.use('/services', serviceRoutes);
 app.use('/assistant', assistantRoutes);
 app.use('/chat', chatRoutes);
+app.use('/summary', summaryRoutes);
 
 app.use(errorHandler);
 if (process.env.NODE_ENV !== 'test') {

--- a/src/routes/summaryRoutes.js
+++ b/src/routes/summaryRoutes.js
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import { monthly } from '../controllers/summaryController.js';
+
+const router = Router();
+
+router.get('/monthly', monthly);
+
+export default router;

--- a/tests/integration/bills.test.js
+++ b/tests/integration/bills.test.js
@@ -99,4 +99,13 @@ describe('Bill endpoints', () => {
     expect(res.status).toBe(200);
     expect(res.body.paid).toBe(100);
   });
+
+  it('GET /summary/monthly should return monthly summary', async () => {
+    billService.getMonthlyStatusByMonth.mockResolvedValue([
+      { month: '2025-07', status: 'paid', total: 120, count: 2 }
+    ]);
+    const res = await request(app).get('/summary/monthly');
+    expect(res.status).toBe(200);
+    expect(res.body[0].month).toBe('2025-07');
+  });
 });


### PR DESCRIPTION
## Summary
- add monthly summary endpoint and controller
- allow payment provider selection when paying bills
- create Summary page and navigation link
- include service name/description for bill queries
- drop obsolete fields from Bill model
- update tests for new logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844ebaff570832fade0f660a2f5602c