### PR TITLE
💳 Add modern modal for payment provider selection

### DIFF
--- a/frontend/src/components/PayDialog.vue
+++ b/frontend/src/components/PayDialog.vue
@@ -1,0 +1,58 @@
+<template>
+  <v-dialog v-model="dialog" max-width="400" @update:modelValue="val => !val && close()">
+    <v-card>
+      <v-card-title>Seleccionar medio de pago</v-card-title>
+      <v-card-text>
+        <v-select
+          v-model="provider"
+          :items="providers"
+          label="Medio de pago"
+          density="compact"
+          required
+        />
+      </v-card-text>
+      <v-card-actions>
+        <v-spacer />
+        <v-btn variant="text" @click="close">Cancelar</v-btn>
+        <v-btn variant="text" color="green" @click="confirm" :disabled="!provider">Confirmar</v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script setup>
+import { ref, watch } from 'vue';
+import api from '../api.js';
+
+const props = defineProps({ bill: Object });
+const emit = defineEmits(['paid', 'close']);
+
+const dialog = ref(false);
+const providers = ['Visa', 'Mastercard', 'MODO', 'MercadoPago', 'Google Play', 'PayPal'];
+const provider = ref('');
+
+watch(
+  () => props.bill,
+  (b) => {
+    dialog.value = !!b;
+    provider.value = b?.paymentProvider || '';
+  },
+  { immediate: true }
+);
+
+function close() {
+  dialog.value = false;
+  emit('close');
+}
+
+async function confirm() {
+  if (!provider.value) return;
+  await api.put(`/bills/${props.bill.id}`, {
+    status: 'paid',
+    paymentProvider: provider.value
+  });
+  emit('paid');
+  close();
+}
+</script>
+

--- a/frontend/src/views/ServiceBills.vue
+++ b/frontend/src/views/ServiceBills.vue
@@ -88,6 +88,12 @@
       @updated="onUpdated"
       @close="closeEdit"
     />
+    <PayDialog
+      v-if="payingBill"
+      :bill="payingBill"
+      @paid="onPaid"
+      @close="closePay"
+    />
   </v-container>
 </template>
 
@@ -96,6 +102,7 @@ import { ref, onMounted, computed } from 'vue';
 import { useRoute } from 'vue-router';
 import api from '../api.js';
 import EditBillForm from '../components/EditBillForm.vue';
+import PayDialog from '../components/PayDialog.vue';
 
 const route = useRoute();
 const id = route.params.id;
@@ -106,6 +113,7 @@ const loading = ref(false);
 const error = ref(null);
 const filter = ref('');
 const editingBill = ref(null);
+const payingBill = ref(null);
 
 const statusOptions = [
   { title: 'All', value: '' },
@@ -187,13 +195,16 @@ async function onUpdated() {
 }
 
 async function pay(bill) {
-  try {
-    const provider = prompt('Payment provider', bill.paymentProvider || '');
-    await api.put(`/bills/${bill.id}`, { status: 'paid', paymentProvider: provider });
-    await fetchData();
-  } catch (err) {
-    error.value = err.message;
-  }
+  payingBill.value = bill;
+}
+
+function closePay() {
+  payingBill.value = null;
+}
+
+async function onPaid() {
+  await fetchData();
+  closePay();
 }
 
 async function remove(bill) {


### PR DESCRIPTION
## Summary
- add `PayDialog` component with Vuetify modal and select
- integrate `PayDialog` into `ServiceBills` view
- open modal when paying a pending bill and send provider on confirm

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844f4d3fb20832f9713f338d4c33f4e