### PR TITLE
🤖 Add Mail Notifier Agent to backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,7 @@ PORT=3000
 
 OPENAI_API_KEY="your-api-key"
 OPENAI_MODEL="gpt-3.5-turbo"
+
+EMAIL_FROM="your-email@gmail.com"
+EMAIL_PASS="your-email-password"
+EMAIL_TO="recipient@example.com"

--- a/notifier/cron.js
+++ b/notifier/cron.js
@@ -1,0 +1,49 @@
+import cron from 'node-cron';
+import nodemailer from 'nodemailer';
+import dotenv from 'dotenv';
+import { getUpcomingBills } from '../src/services/billService.js';
+
+dotenv.config();
+
+const transporter = nodemailer.createTransport({
+  service: 'gmail',
+  auth: {
+    user: process.env.EMAIL_FROM,
+    pass: process.env.EMAIL_PASS
+  }
+});
+
+export const notifyUpcomingBills = async () => {
+  try {
+    const bills = await getUpcomingBills();
+    if (!bills.length) {
+      console.log('No upcoming bills to notify.');
+      return;
+    }
+
+    const list = bills
+      .map((b) => {
+        const url = `${process.env.FRONTEND_URL}/services/${b.serviceId}`;
+        const amount = `$${b.amount.toLocaleString('es-AR')}`;
+        const due = new Date(b.dueDate).toLocaleDateString('es-AR');
+        return `Servicio: ${b.name}<br/>Monto: ${amount}<br/>Vence: ${due}<br/><a href="${url}">🔗 Ver factura → ${url}</a>`;
+      })
+      .join('<br/><br/>');
+
+    await transporter.sendMail({
+      from: process.env.EMAIL_FROM,
+      to: process.env.EMAIL_TO,
+      subject: '📬 Recordatorio: Facturas próximas a vencer',
+      html: list
+    });
+    console.log('Upcoming bills notification sent.');
+  } catch (err) {
+    console.error('Error sending notification', err);
+  }
+};
+
+cron.schedule('0 9 * * *', notifyUpcomingBills);
+
+if (process.argv[1] === new URL('', import.meta.url).pathname) {
+  notifyUpcomingBills().then(() => process.exit(0)).catch(() => process.exit(1));
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
         "node-cron": "^3.0.3",
+        "nodemailer": "^7.0.3",
         "openai": "^4.104.0",
         "prisma": "^6.9.0",
         "uuid": "^9.0.0",
@@ -6151,6 +6152,15 @@
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nodemailer": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.3.tgz",
+      "integrity": "sha512-Ajq6Sz1x7cIK3pN6KesGTah+1gnwMnx5gKl3piQlQQE/PwyJ4Mbc8is2psWYxK3RJTVeqsDaCv8ZzXLCDHMTZw==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/nodemon": {
       "version": "3.1.10",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test:unit": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "test:integration": "vitest run",
     "migrate": "prisma migrate deploy",
-    "seed": "node prisma/seed.js"
+    "seed": "node prisma/seed.js",
+    "notify": "node notifier/cron.js"
   },
   "keywords": [],
   "author": "",
@@ -25,6 +26,7 @@
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "node-cron": "^3.0.3",
+    "nodemailer": "^7.0.3",
     "openai": "^4.104.0",
     "prisma": "^6.9.0",
     "uuid": "^9.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ import summaryRoutes from './routes/summaryRoutes.js';
 import logger from './middleware/logger.js';
 import errorHandler from './middleware/errorHandler.js';
 import './reminder.js';
+import '../notifier/cron.js';
 import prisma from './db/prismaClient.js';
 
 dotenv.config();


### PR DESCRIPTION
## Summary
- add Gmail-based notifier in `notifier/cron.js`
- load new email variables in `.env.example`
- import notifier into backend startup
- add `nodemailer` dependency and `notify` script

## Testing
- `npm test`
- `npm run notify` *(fails: @prisma/client did not initialize yet)*

------
https://chatgpt.com/codex/tasks/task_e_6844f6eb0718832f9cd027ad8df43105