### PR TITLE
🤖 Add Financial Chatbot Assistant logic to frontend

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -30,12 +30,6 @@
           title="Resumen"
           :active="route.path.startsWith('/summary')"
         />
-        <v-list-item
-          to="/assistant"
-          prepend-icon="mdi-robot"
-          title="Assistant"
-          :active="route.path.startsWith('/assistant')"
-        />
       </v-list>
     </v-navigation-drawer>
 
@@ -52,6 +46,7 @@
       </v-container>
     </v-main>
     <div v-if="toast" class="toast">{{ toast }}</div>
+    <ChatbotWidget />
   </v-app>
 </template>
 
@@ -59,6 +54,7 @@
 import { ref, watch } from 'vue'
 import { useRoute } from 'vue-router'
 import { useDisplay } from 'vuetify'
+import ChatbotWidget from './components/ChatbotWidget.vue'
 
 const route = useRoute()
 const display = useDisplay()

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -2,7 +2,6 @@ import { createRouter, createWebHistory } from 'vue-router';
 import Dashboard from '../views/Dashboard.vue';
 import PaymentHistory from '../views/PaymentHistory.vue';
 import Analytics from '../views/Analytics.vue';
-import Assistant from '../views/Assistant.vue';
 import ServiceBills from '../views/ServiceBills.vue';
 import Summary from '../views/Summary.vue';
 
@@ -11,7 +10,6 @@ const routes = [
   { path: '/services/:id', component: ServiceBills },
   { path: '/history/:name?', component: PaymentHistory, props: true },
   { path: '/analytics', component: Analytics },
-  { path: '/assistant', component: Assistant },
   { path: '/summary', component: Summary }
 ];
 


### PR DESCRIPTION
## Summary
- replace the Assistant view with a floating chat widget
- remove the `/assistant` route and navigation item
- persist chat history across navigation via `localStorage`

## Testing
- `npm --prefix frontend install` *(fails: dependency resolution error)*

------
https://chatgpt.com/codex/tasks/task_e_6844ff19123c832fbf1f44914b36735f