### PR TITLE
🤖 Add DataModelNormalization logic to backend

### DIFF
--- a/__tests__/unit/services/billService.test.js
+++ b/__tests__/unit/services/billService.test.js
@@ -55,14 +55,11 @@ describe('billService listBills', () => {
 describe('billService updateBill', () => {
   const existing = {
     id: '1',
-    name: 'Netflix',
-    description: 'Streaming',
     amount: 10,
     dueDate: new Date('2024-01-01T00:00:00Z'),
     status: 'pending',
     category: 'subscriptions',
     autoRenew: true,
-    paymentProvider: 'Visa',
     recurrence: 'monthly'
   };
 
@@ -78,7 +75,7 @@ describe('billService updateBill', () => {
     prisma.bill.update.mockResolvedValue({ ...existing, status: 'paid', paidAt: new Date() });
     prisma.bill.create.mockResolvedValue({ ...existing, id: '2' });
 
-    const result = await billService.updateBill('1', { status: 'paid' });
+    const result = await billService.updateBill('1', { status: 'paid', paymentProvider: 'Visa' });
 
     expect(prisma.bill.update).toHaveBeenCalled();
     expect(prisma.bill.create).toHaveBeenCalled();
@@ -92,7 +89,7 @@ describe('billService updateBill', () => {
     prisma.service.findUnique.mockResolvedValue({ name: 'Netflix' });
     prisma.bill.update.mockResolvedValue({ ...noRenew, status: 'paid' });
 
-    const result = await billService.updateBill('1', { status: 'paid' });
+    const result = await billService.updateBill('1', { status: 'paid', paymentProvider: 'Visa' });
 
     expect(prisma.bill.create).not.toHaveBeenCalled();
     expect(addPayment).toHaveBeenCalled();

--- a/prisma/migrations/normalize-models/migration.sql
+++ b/prisma/migrations/normalize-models/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `Bill` DROP COLUMN `paymentProvider`, MODIFY `serviceId` VARCHAR(191) NOT NULL;
+ALTER TABLE `Payment` DROP COLUMN `name`, DROP COLUMN `dueDate`, DROP COLUMN `recurrence`, DROP COLUMN `category`, MODIFY `paymentProvider` VARCHAR(191) NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -13,15 +13,15 @@ model Bill {
   dueDate         DateTime
   status          String
   category        String
-  paymentProvider String?
-  serviceId       String?
+  serviceId       String
   autoRenew       Boolean  @default(false)
   recurrence      String   @default("none")
   paidAt          DateTime?
   createdAt       DateTime @default(now())
   updatedAt       DateTime @updatedAt
 
-  Service Service? @relation(fields: [serviceId], references: [id])
+  Service   Service   @relation(fields: [serviceId], references: [id])
+  payments  Payment[]
 
   @@index([serviceId])
 }
@@ -29,13 +29,9 @@ model Bill {
 model Payment {
   id              String   @id @default(uuid())
   billId          String
-  name            String
   amount          Float
-  dueDate         DateTime
   paidAt          DateTime
-  paymentProvider String?
-  recurrence      String   @default("none")
-  category        String?
+  paymentProvider String
 
   Bill Bill @relation(fields: [billId], references: [id], onDelete: Cascade)
 

--- a/src/db/paymentsDB.js
+++ b/src/db/paymentsDB.js
@@ -6,10 +6,18 @@ export const addPayment = async (payment) => {
 
 export const getPaymentsByName = async (name) => {
   return prisma.payment.findMany({
-    where: { name },
+    where: {
+      Bill: {
+        Service: { name }
+      }
+    },
+    include: { Bill: { include: { Service: true } } },
     orderBy: { paidAt: 'desc' }
   });
 };
 
 export const getAllPayments = async () =>
-  prisma.payment.findMany({ orderBy: { paidAt: 'desc' } });
+  prisma.payment.findMany({
+    include: { Bill: { include: { Service: true } } },
+    orderBy: { paidAt: 'desc' }
+  });

--- a/src/services/billService.js
+++ b/src/services/billService.js
@@ -17,7 +17,6 @@ export const listBills = async (query = {}) => {
     search,
     category,
     status,
-    paymentProvider,
     serviceId,
     recurrence,
     sort = 'dueDate',
@@ -34,7 +33,6 @@ export const listBills = async (query = {}) => {
   }
   if (category) where.category = category;
   if (status) where.status = status;
-  if (paymentProvider) where.paymentProvider = paymentProvider;
   if (recurrence) where.recurrence = recurrence;
   if (serviceId) where.serviceId = serviceId;
 
@@ -72,8 +70,7 @@ export const addBill = async (data) => {
     let service = await prisma.service.findFirst({
       where: {
         name: data.name,
-        category: data.category,
-        paymentProvider: data.paymentProvider || ''
+        category: data.category
       }
     });
     if (!service) {
@@ -82,7 +79,6 @@ export const addBill = async (data) => {
           name: data.name,
           description: data.description,
           category: data.category,
-          paymentProvider: data.paymentProvider || '',
           recurrence: data.recurrence || 'none',
           autoRenew: data.autoRenew ?? false
         }
@@ -96,7 +92,6 @@ export const addBill = async (data) => {
     data: {
       status: 'pending',
       autoRenew: false,
-      paymentProvider: data.paymentProvider || '',
       recurrence: data.recurrence || 'none',
       serviceId,
       ...billData
@@ -147,23 +142,17 @@ export const updateBill = async (id, data) => {
         dueDate: due,
         status: 'pending',
         autoRenew: updated.autoRenew,
-        paymentProvider: updated.paymentProvider,
         recurrence: updated.recurrence || 'none'
       }
     });
   }
 
   if (data.status === 'paid' && existing.status !== 'paid') {
-    const service = await prisma.service.findUnique({ where: { id: updated.serviceId } });
     await addPayment({
       billId: updated.id,
-      name: service?.name || '',
       amount: updated.amount,
-      dueDate: updated.dueDate,
       paidAt: new Date().toISOString(),
-      paymentProvider: updated.paymentProvider,
-      category: updated.category,
-      recurrence: updated.recurrence || 'none'
+      paymentProvider: data.paymentProvider || 'unknown'
     });
   }
 

--- a/tests/integration/bills.test.js
+++ b/tests/integration/bills.test.js
@@ -22,7 +22,6 @@ const sampleBill = {
   dueDate: new Date().toISOString(),
   status: 'pending',
   category: 'utilities',
-  paymentProvider: 'Visa',
   autoRenew: false,
   recurrence: 'none'
 };
@@ -41,8 +40,8 @@ describe('Bill endpoints', () => {
 
   it('GET /bills with filters should pass query to service', async () => {
     billService.listBills.mockResolvedValue({ total: 0, page: 1, limit: 10, data: [] });
-    await request(app).get('/bills').query({ category: 'utilities', paymentProvider: 'Visa' });
-    expect(billService.listBills).toHaveBeenCalledWith({ category: 'utilities', paymentProvider: 'Visa' });
+    await request(app).get('/bills').query({ category: 'utilities' });
+    expect(billService.listBills).toHaveBeenCalledWith({ category: 'utilities' });
   });
 
   it('GET /bills/:id should return bill by id', async () => {

--- a/tests/integration/payments.test.js
+++ b/tests/integration/payments.test.js
@@ -14,7 +14,13 @@ import * as paymentService from '../../src/services/paymentService.js';
 
 vi.mock('../../src/services/paymentService.js');
 
-const sample = { id: '1', name: 'Internet', amount: 50, paidAt: new Date().toISOString(), dueDate: new Date().toISOString(), paymentProvider: 'Visa', recurrence: 'none', category: 'utilities' };
+const sample = {
+  id: '1',
+  amount: 50,
+  paidAt: new Date().toISOString(),
+  paymentProvider: 'Visa',
+  Bill: { Service: { name: 'Internet' } }
+};
 
 describe('Payment endpoints', () => {
   beforeEach(() => vi.resetAllMocks());
@@ -23,7 +29,7 @@ describe('Payment endpoints', () => {
     paymentService.listPayments.mockResolvedValue([sample]);
     const res = await request(app).get('/payments');
     expect(res.status).toBe(200);
-    expect(res.body[0].name).toBe('Internet');
+    expect(res.body[0].Bill.Service.name).toBe('Internet');
   });
 
   it('GET /payments/:name should filter by name', async () => {


### PR DESCRIPTION
## Summary
- drop paymentProvider from `Bill` and move to `Payment`
- simplify `Payment` fields and add relation in Prisma schema
- update service layer and DB helpers for new schema
- adjust tests to use new models
- add manual migration SQL for schema changes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684502d3cd98832f820865fb6baafe16