### PR TITLE
💳 Mostrar múltiples medios de pago por factura en el listado

### DIFF
--- a/__tests__/unit/services/billService.test.js
+++ b/__tests__/unit/services/billService.test.js
@@ -46,9 +46,14 @@ describe('billService listBills', () => {
       orderBy: { dueDate: 'asc' },
       skip: 5,
       take: 5,
-      include: { Service: true }
+      include: { Service: true, payments: true }
     });
-    expect(result).toEqual({ total: 1, page: 2, limit: 5, data: [{ id: '1', name: undefined, description: undefined }] });
+    expect(result).toEqual({
+      total: 1,
+      page: 2,
+      limit: 5,
+      data: [{ id: '1', name: undefined, description: undefined, payments: undefined }]
+    });
   });
 });
 
@@ -75,7 +80,10 @@ describe('billService updateBill', () => {
     prisma.bill.update.mockResolvedValue({ ...existing, status: 'paid', paidAt: new Date() });
     prisma.bill.create.mockResolvedValue({ ...existing, id: '2' });
 
-    const result = await billService.updateBill('1', { status: 'paid', paymentProvider: 'Visa' });
+    const result = await billService.updateBill('1', {
+      status: 'paid',
+      payments: [{ amount: 10, paymentProvider: 'Visa' }]
+    });
 
     expect(prisma.bill.update).toHaveBeenCalled();
     expect(prisma.bill.create).toHaveBeenCalled();
@@ -89,7 +97,10 @@ describe('billService updateBill', () => {
     prisma.service.findUnique.mockResolvedValue({ name: 'Netflix' });
     prisma.bill.update.mockResolvedValue({ ...noRenew, status: 'paid' });
 
-    const result = await billService.updateBill('1', { status: 'paid', paymentProvider: 'Visa' });
+    const result = await billService.updateBill('1', {
+      status: 'paid',
+      payments: [{ amount: 10, paymentProvider: 'Visa' }]
+    });
 
     expect(prisma.bill.create).not.toHaveBeenCalled();
     expect(addPayment).toHaveBeenCalled();

--- a/frontend/src/components/BillTable.vue
+++ b/frontend/src/components/BillTable.vue
@@ -56,10 +56,8 @@
         Invoices: {{ item.invoiceCount }}
       </template>
       <template #item.paymentProvider="{ item }">
-        <v-chip size="small">
-          <v-icon start>{{ providerIcon(item.paymentProvider) }}</v-icon>
-          {{ item.paymentProvider }}
-        </v-chip>
+        <span v-if="item.payments?.length">{{ summarize(item.payments) }}</span>
+        <v-icon v-else color="grey">mdi-minus</v-icon>
       </template>
       <template #item.status="{ item }">
         <v-chip :color="statusColor(item.status)" size="small" class="text-white">
@@ -213,7 +211,7 @@ const totalPages = computed(() => Math.ceil(total.value / limit) || 1);
 const groupedBills = computed(() => {
   const map = new Map();
   bills.value.forEach((bill) => {
-    const key = bill.serviceId || `${bill.name}|${bill.paymentProvider}|${bill.category}`;
+    const key = bill.serviceId || `${bill.name}|${bill.category}`;
     if (!map.has(key)) map.set(key, []);
     map.get(key).push(bill);
   });
@@ -244,6 +242,17 @@ function providerIcon(name) {
     PayPal: 'mdi-currency-usd'
   };
   return icons[name] || 'mdi-cash';
+}
+
+function summarize(payments) {
+  const map = {};
+  payments.forEach((p) => {
+    if (!map[p.paymentProvider]) map[p.paymentProvider] = 0;
+    map[p.paymentProvider] += Number(p.amount);
+  });
+  return Object.entries(map)
+    .map(([prov, amt]) => `${prov} ($${amt.toFixed(2)})`)
+    .join(' + ');
 }
 
 function edit(bill) {

--- a/frontend/src/components/PayDialog.vue
+++ b/frontend/src/components/PayDialog.vue
@@ -1,27 +1,48 @@
 <template>
-  <v-dialog v-model="dialog" max-width="400" @update:modelValue="val => !val && close()">
+  <v-dialog v-model="dialog" max-width="500" @update:modelValue="val => !val && close()">
     <v-card>
-      <v-card-title>Seleccionar medio de pago</v-card-title>
+      <v-card-title>Pagar factura</v-card-title>
       <v-card-text>
-        <v-select
-          v-model="provider"
-          :items="providers"
-          label="Medio de pago"
-          density="compact"
-          required
-        />
+        <div v-for="(p, i) in payments" :key="i" class="d-flex align-center mb-2">
+          <v-text-field
+            v-model.number="p.amount"
+            type="number"
+            label="Monto"
+            density="compact"
+            class="mr-2"
+            style="max-width:100px"
+          />
+          <v-select
+            v-model="p.paymentProvider"
+            :items="providers"
+            label="Medio de pago"
+            density="compact"
+            class="flex-grow-1"
+          />
+          <v-btn icon size="small" @click="remove(i)" v-if="payments.length > 1">
+            <v-icon>mdi-close</v-icon>
+          </v-btn>
+        </div>
+        <v-btn icon size="small" class="mb-2" @click="addLine">
+          <v-icon>mdi-plus</v-icon>
+        </v-btn>
+        <div class="text-right font-weight-bold">
+          Total: {{ total.toFixed(2) }} / {{ props.bill?.amount.toFixed(2) }}
+        </div>
       </v-card-text>
       <v-card-actions>
         <v-spacer />
         <v-btn variant="text" @click="close">Cancelar</v-btn>
-        <v-btn variant="text" color="green" @click="confirm" :disabled="!provider">Confirmar</v-btn>
+        <v-btn variant="text" color="green" @click="confirm" :disabled="total !== props.bill?.amount">
+          Confirmar
+        </v-btn>
       </v-card-actions>
     </v-card>
   </v-dialog>
 </template>
 
 <script setup>
-import { ref, watch } from 'vue';
+import { ref, watch, computed } from 'vue';
 import api from '../api.js';
 
 const props = defineProps({ bill: Object });
@@ -29,16 +50,26 @@ const emit = defineEmits(['paid', 'close']);
 
 const dialog = ref(false);
 const providers = ['Visa', 'Mastercard', 'MODO', 'MercadoPago', 'Google Play', 'PayPal'];
-const provider = ref('');
+const payments = ref([]);
 
 watch(
   () => props.bill,
   (b) => {
     dialog.value = !!b;
-    provider.value = b?.paymentProvider || '';
+    payments.value = b ? [{ amount: b.amount, paymentProvider: '' }] : [];
   },
   { immediate: true }
 );
+
+const total = computed(() => payments.value.reduce((s, p) => s + Number(p.amount || 0), 0));
+
+function addLine() {
+  payments.value.push({ amount: 0, paymentProvider: '' });
+}
+
+function remove(i) {
+  payments.value.splice(i, 1);
+}
 
 function close() {
   dialog.value = false;
@@ -46,10 +77,10 @@ function close() {
 }
 
 async function confirm() {
-  if (!provider.value) return;
+  if (total.value !== props.bill.amount) return;
   await api.put(`/bills/${props.bill.id}`, {
     status: 'paid',
-    paymentProvider: provider.value
+    payments: payments.value
   });
   emit('paid');
   close();

--- a/frontend/src/views/ServiceBills.vue
+++ b/frontend/src/views/ServiceBills.vue
@@ -35,7 +35,9 @@
       <template #item.dueDate="{ item }">{{ format(item.dueDate) }}</template>
       <template #item.amount="{ item }">{{ item.amount.toFixed(2) }}</template>
       <template #item.paymentProvider="{ item }">
-        <span v-if="item.paymentProvider">{{ item.paymentProvider }}</span>
+        <span v-if="item.payments?.length">
+          {{ summarize(item.payments) }}
+        </span>
         <v-tooltip v-else text="Agregar medio de pago" location="top">
           <template #activator="{ props }">
             <v-icon
@@ -176,6 +178,17 @@ function statusIcon(status) {
       overdue: 'mdi-alert-circle'
     }[status] || ''
   );
+}
+
+function summarize(payments) {
+  const map = {};
+  payments.forEach((p) => {
+    if (!map[p.paymentProvider]) map[p.paymentProvider] = 0;
+    map[p.paymentProvider] += Number(p.amount);
+  });
+  return Object.entries(map)
+    .map(([prov, amt]) => `${prov} ($${amt.toFixed(2)})`)
+    .join(' + ');
 }
 
 function format(d) {

--- a/src/services/serviceService.js
+++ b/src/services/serviceService.js
@@ -27,7 +27,7 @@ export const listServices = async (query = {}) => {
 export const getServiceById = async (id) =>
   prisma.service.findUnique({
     where: { id },
-    include: { bills: true }
+    include: { bills: { include: { payments: true } } }
   });
 
 export const updateService = async (id, data) => {

--- a/tests/integration/bills.test.js
+++ b/tests/integration/bills.test.js
@@ -67,14 +67,18 @@ describe('Bill endpoints', () => {
 
   it('PUT /bills/:id should update bill', async () => {
     billService.updateBill.mockResolvedValue({ updated: { ...sampleBill, status: 'paid' }, newBill: null });
-    const res = await request(app).put('/bills/1').send({ status: 'paid' });
+    const res = await request(app)
+      .put('/bills/1')
+      .send({ status: 'paid', payments: [{ amount: 50, paymentProvider: 'Visa' }] });
     expect(res.status).toBe(200);
     expect(res.body.updated.status).toBe('paid');
   });
 
   it('PUT /bills/:id should create new bill when auto-renew paid', async () => {
     billService.updateBill.mockResolvedValue({ updated: { ...sampleBill, status: 'paid', autoRenew: true }, newBill: { ...sampleBill, id: '2' } });
-    const res = await request(app).put('/bills/1').send({ status: 'paid' });
+    const res = await request(app)
+      .put('/bills/1')
+      .send({ status: 'paid', payments: [{ amount: 50, paymentProvider: 'Visa' }] });
     expect(res.status).toBe(200);
     expect(res.body.newBill.id).toBe('2');
   });


### PR DESCRIPTION
## Summary
- allow multiple payment lines in PayDialog
- show payment summaries for bills
- include payments in bill service responses
- support array of payments when marking bill as paid
- include payments when fetching a service
- update tests for new API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68450856a824832f982946100879267b